### PR TITLE
`SSTORE` opcode equivalence

### DIFF
--- a/EvmEquivalence.lean
+++ b/EvmEquivalence.lean
@@ -1,3 +1,34 @@
 -- This module serves as the root of the `EvmEquivalence` library.
 -- Import modules here that should be built as part of the library.
-import EvmEquivalence.Basic
+
+-- K generated code
+import EvmEquivalence.KEVM2Lean.Prelude
+import EvmEquivalence.KEVM2Lean.Sorts
+import EvmEquivalence.KEVM2Lean.Inj
+import EvmEquivalence.KEVM2Lean.ScheduleOrdering
+import EvmEquivalence.KEVM2Lean.Func
+import EvmEquivalence.KEVM2Lean.Rewrite
+
+-- Interfaces
+import EvmEquivalence.Interfaces.EvmYulInterface
+import EvmEquivalence.Interfaces.FuncInterface
+import EvmEquivalence.Interfaces.Tactics
+import EvmEquivalence.Interfaces.GasInterface
+import EvmEquivalence.Interfaces.Axioms
+
+-- State Map
+import EvmEquivalence.StateMap
+
+-- Utils
+import EvmEquivalence.Utils.IntUtils
+
+-- Summaries
+import EvmEquivalence.Summaries.StopSummary
+import EvmEquivalence.Summaries.AddSummary
+import EvmEquivalence.Summaries.Push0Summary
+import EvmEquivalence.Summaries.SstoreSummary
+
+-- Equivalence
+import EvmEquivalence.Equivalence.AddEquivalence
+import EvmEquivalence.Equivalence.Push0Equivalence
+import EvmEquivalence.Equivalence.SstoreEquivalence

--- a/EvmEquivalence/Equivalence/AddEquivalence.lean
+++ b/EvmEquivalence/Equivalence/AddEquivalence.lean
@@ -236,7 +236,8 @@ theorem add_prestate_equiv
     gasAvailable := intMap GAS_CELL
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := idMap lhs.Iₐ}
+                  codeOwner := idMap lhs.Iₐ
+                  perm := !lhs.isStatic.val}
     accountMap := Axioms.SortAccountsCellMap lhs.accounts
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap lhs.accessedStorage
@@ -289,7 +290,8 @@ theorem add_poststate_equiv
     gasAvailable := intMap _Val7
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := idMap rhs.Iₐ}
+                  codeOwner := idMap rhs.Iₐ,
+                  perm := !rhs.isStatic.val}
     accountMap := Axioms.SortAccountsCellMap rhs.accounts
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap rhs.accessedStorage

--- a/EvmEquivalence/Equivalence/AddEquivalence.lean
+++ b/EvmEquivalence/Equivalence/AddEquivalence.lean
@@ -228,12 +228,17 @@ theorem add_prestate_equiv
   {_Gen8 : SortCallGasCell}
   {_Gen9 : SortStaticCell}
   (symState : EVM.State):
-  stateMap symState (@addLHS GAS_CELL PC_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) =
+  let lhs := (@addLHS GAS_CELL PC_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  stateMap symState lhs =
   {symState with
     stack := (intMap W0) :: (intMap W1) :: wordStackMap WS
     pc := intMap PC_CELL
     gasAvailable := intMap GAS_CELL
     executionEnv := {symState.executionEnv with code := _Gen0.val}
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC lhs)
+            refundBalance := intMap _Gen17.refund.val
+           }
     returnData := _Gen11.val
     } := rfl
 
@@ -273,12 +278,17 @@ theorem add_poststate_equiv
   (defn_Val4 : chop _Val3 = some _Val4)
   (defn_Val5 : «_+Int_» PC_CELL 1 = some _Val5)
   (symState : EVM.State):
-  stateMap symState (@addRHS _Val0 _Val3 _Val4 _Val5 _Val6 _Val7 K_CELL SCHEDULE_CELL _Val1 _Val2 WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) =
+  let rhs := (@addRHS _Val0 _Val3 _Val4 _Val5 _Val6 _Val7 K_CELL SCHEDULE_CELL _Val1 _Val2 WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  stateMap symState rhs =
   {symState with
     stack := (intMap (chop' («_+Int'_» W0 W1))) :: wordStackMap WS
     pc := intMap («_+Int'_» PC_CELL 1)
     gasAvailable := intMap _Val7
     executionEnv := {symState.executionEnv with code := _Gen0.val}
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC rhs)
+            refundBalance := intMap _Gen17.refund.val
+           }
     returnData := _Gen11.val
     } := by aesop (add simp [«_+Int'_», chop'])
 

--- a/EvmEquivalence/Equivalence/AddEquivalence.lean
+++ b/EvmEquivalence/Equivalence/AddEquivalence.lean
@@ -192,7 +192,7 @@ theorem rw_addLHS_addRHS
   Rewrites
   (@addLHS GAS_CELL PC_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
   (@addRHS _Val0 _Val3 _Val4 _Val5 _Val6 _Val7 K_CELL SCHEDULE_CELL _Val1 _Val2 WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) := by
-  apply Rewrites.SUMMARY_ADD_2_SPEC_BASIC_BLOCK_21_TO_20 <;> try assumption
+  apply Rewrites.ADD_SUMMARY_ADD_SUMMARY_0 <;> try assumption
   simp_all
 
 theorem add_prestate_equiv

--- a/EvmEquivalence/Equivalence/AddEquivalence.lean
+++ b/EvmEquivalence/Equivalence/AddEquivalence.lean
@@ -234,9 +234,12 @@ theorem add_prestate_equiv
     stack := (intMap W0) :: (intMap W1) :: wordStackMap WS
     pc := intMap PC_CELL
     gasAvailable := intMap GAS_CELL
-    executionEnv := {symState.executionEnv with code := _Gen0.val}
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := idMap lhs.Iₐ}
+    accountMap := Axioms.SortAccountsCellMap lhs.accounts
     substate := {symState.substate with
-            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC lhs)
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap lhs.accessedStorage
             refundBalance := intMap _Gen17.refund.val
            }
     returnData := _Gen11.val
@@ -284,13 +287,17 @@ theorem add_poststate_equiv
     stack := (intMap (chop' («_+Int'_» W0 W1))) :: wordStackMap WS
     pc := intMap («_+Int'_» PC_CELL 1)
     gasAvailable := intMap _Val7
-    executionEnv := {symState.executionEnv with code := _Gen0.val}
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := idMap rhs.Iₐ}
+    accountMap := Axioms.SortAccountsCellMap rhs.accounts
     substate := {symState.substate with
-            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC rhs)
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap rhs.accessedStorage
             refundBalance := intMap _Gen17.refund.val
            }
     returnData := _Gen11.val
     } := by aesop (add simp [«_+Int'_», chop'])
+
 
 open AddSummary
 
@@ -356,7 +363,7 @@ theorem step_add_equiv
   cases gas; contradiction
   case succ gas =>
     rw [EVM.step_add_summary] <;> try assumption
-    congr
+    simp [addLHS, addRHS]; constructor <;> try constructor
     . aesop (add simp [GasInterface.cancun_def, «_-Int_», intMap_sub_dist])
     . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
     . aesop (add simp [intMap, chop_def, plusInt_def, intMap_add_dist])
@@ -428,7 +435,7 @@ theorem X_add_equiv
   -- If we don't apply this lemma we cannot rewrite X_add_summary
   have pc_equiv : intMap 0 = UInt256.ofNat 0 := rfl
   rw [pc_equiv, X_add_summary]
-  · aesop (add simp [GasInterface.cancun_def, «_-Int_», chop_def, plusInt_def, intMap_add_dist])
+  · aesop (add simp [GasInterface.cancun_def, «_-Int_», chop_def, plusInt_def, intMap_add_dist, addLHS, addRHS])
       (add safe (by rw [intMap_sub_dist])) (add safe (by apply le_of_lt))
   · aesop (add simp [GasConstants.Gverylow, intMap, UInt256.toSigned])
       (add simp [intMap_toNat, UInt256.ofNat_toNat])

--- a/EvmEquivalence/Equivalence/Push0Equivalence.lean
+++ b/EvmEquivalence/Equivalence/Push0Equivalence.lean
@@ -235,12 +235,17 @@ theorem push0_prestate_equiv
   {_Gen8 : SortCallGasCell}
   {_Gen9 : SortStaticCell}
   {symState : EVM.State}:
-  stateMap symState (@push0LHS GAS_CELL PC_CELL K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) =
+  let lhs := (@push0LHS GAS_CELL PC_CELL K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  stateMap symState lhs =
   {symState with
     stack := wordStackMap WS
     pc := intMap PC_CELL
     gasAvailable := intMap GAS_CELL
     executionEnv := {symState.executionEnv with code := _Gen0.val}
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC lhs)
+            refundBalance := intMap _Gen17.refund.val
+           }
     returnData := _Gen11.val
     } := rfl
 
@@ -278,12 +283,17 @@ theorem push0_poststate_equiv
   {_Gen9 : SortStaticCell}
   {symState : EVM.State}
   (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11):
-  stateMap symState (@push0RHS _Val11 _Val13 K_CELL SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) =
+  let rhs := (@push0RHS _Val11 _Val13 K_CELL SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  stateMap symState rhs =
   {symState with
     stack := .ofNat 0 :: wordStackMap WS
     pc := intMap («_+Int'_» PC_CELL 1)
     gasAvailable := intMap _Val13
     executionEnv := {symState.executionEnv with code := _Gen0.val}
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC rhs)
+            refundBalance := intMap _Gen17.refund.val
+           }
     returnData := _Gen11.val
     } := by aesop (add simp [«_+Int'_»])
 

--- a/EvmEquivalence/Equivalence/Push0Equivalence.lean
+++ b/EvmEquivalence/Equivalence/Push0Equivalence.lean
@@ -241,9 +241,12 @@ theorem push0_prestate_equiv
     stack := wordStackMap WS
     pc := intMap PC_CELL
     gasAvailable := intMap GAS_CELL
-    executionEnv := {symState.executionEnv with code := _Gen0.val}
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := idMap lhs.Iₐ}
+    accountMap := Axioms.SortAccountsCellMap lhs.accounts
     substate := {symState.substate with
-            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC lhs)
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap lhs.accessedStorage
             refundBalance := intMap _Gen17.refund.val
            }
     returnData := _Gen11.val
@@ -289,9 +292,12 @@ theorem push0_poststate_equiv
     stack := .ofNat 0 :: wordStackMap WS
     pc := intMap («_+Int'_» PC_CELL 1)
     gasAvailable := intMap _Val13
-    executionEnv := {symState.executionEnv with code := _Gen0.val}
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := idMap rhs.Iₐ}
+    accountMap := Axioms.SortAccountsCellMap rhs.accounts
     substate := {symState.substate with
-            accessedStorageKeys :=  Axioms.mapAccessStorageCell (accessedStorageOfGTC rhs)
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap rhs.accessedStorage
             refundBalance := intMap _Gen17.refund.val
            }
     returnData := _Gen11.val
@@ -360,7 +366,7 @@ theorem step_push0_equiv
   rw [push0_prestate_equiv, (push0_poststate_equiv PC_CELL)]
   cases gas; contradiction
   rw [EVM.step_push0_summary] <;> try assumption
-  congr
+  simp [push0LHS, push0RHS]; constructor <;> try constructor
   . aesop (add simp [GasConstants.Gbase, «_-Int_», cancun_def, intMap_sub_dist])
   . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
   . aesop (add simp [«_+Int_»])
@@ -434,7 +440,7 @@ theorem X_push0_equiv
   . rw [intMap_toNat, Int.toNat_eq_zero] at cgc <;> linarith
   . have pc_equiv : intMap 0 = UInt256.ofNat 0 := rfl
     rw [pc_equiv, ←intMap_toNat, X_push0_summary] <;> first | linarith | try simp
-    . aesop (add simp [«_-Int_», intMap_sub_dist])
+    . aesop (add simp [«_-Int_», intMap_sub_dist, push0LHS, push0RHS])
       (add safe (by rw [intMap_sub_dist])) (add safe (by linarith))
     . rw [intMap_toNat] <;> aesop (add safe (by linarith))
     . simp [defn_Val3] at defn_Val6; subst defn_Val6

--- a/EvmEquivalence/Equivalence/Push0Equivalence.lean
+++ b/EvmEquivalence/Equivalence/Push0Equivalence.lean
@@ -243,7 +243,8 @@ theorem push0_prestate_equiv
     gasAvailable := intMap GAS_CELL
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := idMap lhs.Iₐ}
+                  codeOwner := idMap lhs.Iₐ,
+                  perm := !lhs.isStatic.val}
     accountMap := Axioms.SortAccountsCellMap lhs.accounts
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap lhs.accessedStorage
@@ -294,7 +295,8 @@ theorem push0_poststate_equiv
     gasAvailable := intMap _Val13
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := idMap rhs.Iₐ}
+                  codeOwner := idMap rhs.Iₐ,
+                  perm := !rhs.isStatic.val}
     accountMap := Axioms.SortAccountsCellMap rhs.accounts
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap rhs.accessedStorage

--- a/EvmEquivalence/Equivalence/Push0Equivalence.lean
+++ b/EvmEquivalence/Equivalence/Push0Equivalence.lean
@@ -199,7 +199,7 @@ theorem rw_push0LHS_push0RHS
   Rewrites
   (@push0LHS GAS_CELL PC_CELL K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
   (@push0RHS _Val11 _Val13 K_CELL SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9) :=
-  by apply Rewrites.SUMMARY_PUSHZERO_0_SPEC_BASIC_BLOCK_25_TO_24 <;> try assumption
+  by apply Rewrites.PUSHZERO_SUMMARY_PUSHZERO_SUMMARY_1 <;> try assumption
      all_goals simp_all [notBool_def, andBool_def]
 
 theorem push0_prestate_equiv

--- a/EvmEquivalence/Equivalence/README.md
+++ b/EvmEquivalence/Equivalence/README.md
@@ -17,7 +17,7 @@ Given this, let's understand the anatomy of a Lean-generated rewrite rule.
 
 Rewrite rules are comprised of
 - A left-hand side (lhs): `KEVM` state prior to the execution of an opcode. Also known as prestate.
-- A right-hand side (rhs): `KEVM` state derived from the execution of an opcode on the lhs. Also known as prestate.
+- A right-hand side (rhs): `KEVM` state derived from the execution of an opcode on the lhs. Also known as poststate.
 - All the variables involved in the definition of the lhs and rhs.
 - All the conditions that give meaning to the variables present in the lhs and rhs.
 

--- a/EvmEquivalence/Equivalence/README.md
+++ b/EvmEquivalence/Equivalence/README.md
@@ -29,25 +29,25 @@ The structure of Lean-generated rewrite rules is as follows:
 inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop where
 | NAME_OF_THE_RULE
   {Var : CustomType} -- Variables are declared as implicit
-  ...                 -- A bunch more of variables
+  ...                 -- A bunch more variables
   (defn_Valn : f other_variables = some Valn) -- The meaning of the `_Valn` is explicitly given
-  ...                 -- A bunch more of conditions
+  ...                 -- A bunch more conditions
   : Rewrites LHS RHS  -- Given all the conditions (`defn_Val*`) above, we can state LHS => RHS
 ```
 
-Here `LHS` and `RHS` are representations of the `KEVM` pre and post states with the appropriate structure given the `defn_Val*` conditions.
+Here `LHS` and `RHS` are representations of the `KEVM` pre and post states with the appropriate structure given by the `defn_Val*` conditions.
 
 ### Proper definition of pre and post states
 
 The first step in all proofs is to have a precise definition of `LHS` and `RHS`.
 The naming convention is `opcode?HS` for each (e.g. `addLHS` for the prestate of the `ADD` opcode).
 
-Note that for these definitions we don't need any of the `defn_Val*` conditions yet, since we only care about the structural content of both states.
+Note that for these definitions we don't need any of the `defn_Val*` conditions yet, since we only care about the structural content of both states. That is, we don't need to know yet how the variables in these definitions relate to each other.
 
 #### Theorems-as-tests
 
-Once we have a definition of the `LHS` and `RHS` we can test it with a theorem stating that, indeed, given all the `defn_Val*` preconditions,
-`Rewrites opcodeLHS opcodeRHS` holds.
+Once we have a definition of the `LHS` and `RHS` we want to test them and make sure they are the right ones.
+To this end, we can prove a theorem stating that, indeed, given all the `defn_Val*` preconditions, `Rewrites opcodeLHS opcodeRHS` holds.
 
 The general name for that theorem is `rw_opcodeLHS_opcodeRHS`.
 
@@ -71,21 +71,21 @@ Hence, we will state `pc := intMap («_+Int'_» PC_CELL 1)` instead of `pc := in
 ### Final proofs
 
 The `EvmYul` functions that reflect the semantics of executing an opcode are `EVM.step` and `X` found in [`EvmYul/EVM/Semantics.lean`](https://github.com/NethermindEth/EVMYulLean/blob/main/EvmYul/EVM/Semantics.lean).
-Since the effects of opcode execution are separated between the two functions (for instance, `step` doesn't assign gas costs), we have
-one theorem for each function stating broadly the same.
+Since the full effects of opcode execution are separated between the two functions (for instance, `step` doesn't assign gas costs), we have one theorem for each function stating broadly the same.
 
 The statement is, for `f` being `EVM.step` or `EVM.X`:
 > Given the `KEVM` prestate `LHS`, `f (stateMap LHS) = stateMap RHS`
 That is, mapping the `KEVM` prestate to `EvmYul` and executing either `EVM.step` or `EVM.X` gives us the mapped `KEVM` poststate.
 
-An number of additional hypothesis from the `defn_Val*` is added to each theorem. Revisiting and sanity-checking these hypothesis is worthwhile.
+A number of additional hypotheses from the `defn_Val*` is added to each theorem. Revisiting and sanity-checking these hypotheses is worthwhile.
 The vast majority of them stem from the fact that [`KEVM` summaries](https://github.com/runtimeverification/evm-semantics/tree/master/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/summaries)
 assume that the `LHS` is a valid `KEVM` state. This means that conditions such as `PC_CELL < 2^256` are not enforced by the summaries and
 therefore need to be added as assumptions to obtain equivalence.
 
 These assumptions are present in the `KEVM` semantics, but they are enforced before triggering opcode execution.
+That is, the assumptions are not present in the rewrite rule of the opcodes, but in rewrite rules leading to opcode execution.
 
 ### Future work
 
 Notably, these proofs are only in one direction. Namely, we show that if `KEVM` computes something, `EvmYul` agrees with a
-translation of that computation. It remains to prove the converse. Namely, that `KEVM` agrees with a translation of what `EvmYul` computes.
+translation of that computation. It remains to prove the converse: that `KEVM` agrees with a translation of what `EvmYul` computes.

--- a/EvmEquivalence/Equivalence/README.md
+++ b/EvmEquivalence/Equivalence/README.md
@@ -1,0 +1,91 @@
+# Opcode Equivalence
+
+This folder contains the equivalence proofs for opcode execution between the [`EvmYul`](https://github.com/nethermindEth/EVMYulLean/)
+and [`KEVM`](https://github.com/runtimeverification/evm-semantics) models.
+
+The proofs follow the following structure.
+
+## Proof sketch
+
+K rewrite rules are encoded as constructors of the inductive type `Rewrites` found in [Rewrite.lean](../KEVM2Lean/Rewrite.lean).
+That is, each constructor of `Rewrites` is a K rewrite rule. In particular, these K rewrite rules are generated from the [`KEVM` summaries](https://github.com/runtimeverification/evm-semantics/tree/master/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/summaries).
+So the rewrite rules in `Rewrites` already encapsulate the computational content of executing an opcode in `KEVM`.
+
+Given this, let's understand the anatomy of a Lean-generated rewrite rule.
+
+### Anatomy of a rewrite rule
+
+Rewrite rules are comprised of
+- A left-hand side (lhs): a `KEVM` state prior to the execution of an opcode. Also known as prestate.
+- A right-hand side (rhs): a `KEVM` state derived from the execution of an opcode on the lhs. Also known as prestate.
+- All the variables involved in the definition of the lhs and rhs.
+- All the conditions that give meaning to the variables present in the lhs and rhs.
+
+Structurally we only need the first three items to make a rewrite rule type-check.
+The actual meaning of rewrite rules is encoded in all these conditions named `defn_Val*`.
+
+The structure of Lean-generated rewrite rules is as follows:
+```Lean
+inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop where
+| NAME_OF_THE_RULE
+  {Var : CustomType} -- Variables are declared as implicit
+  ...                 -- A bunch more of variables
+  (defn_Valn : f other_variables = some Valn) -- The meaning of the `_Valn` is explicitly given
+  ...                 -- A bunch more of conditions
+  : Rewrites LHS RHS  -- Given all the conditions (`defn_Val*`) above we can state LHS => RHS
+```
+
+Here `LHS` and `RHS` are representations of the `KEVM` pre and post states with the appropriate structure given the `defn_Val*` conditions.
+
+### Proper definition of pre and post states
+
+The first step in all proofs is to have a precise definition of `LHS` and `RHS`.
+The naming convention is `opcode?HS` for each (e.g. `addLHS` for the prestate of the `ADD` opcode).
+
+Note that for these definitions we don't need any of the `defn_Val*` conditions yet, since we only care about the structural content of both states.
+
+#### Theorems-as-tests
+
+Once we have a definition of the `LHS` and `RHS` we can test it with a theorem stating that, indeed, given all the `defn_Val*` preconditions,
+`Rewrites opcodeLHS opcodeRHS` holds.
+
+The general name for that theorem is `rw_opcodeLHS_opcodeRHS`.
+
+### Projecting `KEVM` states into `EvmYul`
+
+The next step is to reflect the resulting `EvmYul` state after transforming the `LHS` and `RHS` via the `stateMap` function.
+The `stateMap` function is defined in [`StateMap.lean`](../StateMap.lean).
+
+This reflection is done through the `opcode_prestate_equiv` and `opcode_poststate_equiv` theorems for the `opcodeLHS` and `opcodeRHS` respectively.
+These theorems are mostly structural, especially the `opcodeLHS`. However, the `opcode_poststate_equiv` is used to specify further what are the recorded effects of executing `opcode` in `KEVM`.
+
+To exemplify what this means, consider `add_poststate_equiv` in [`AddEquivalence.lean`](./AddEquivalence.lean).
+
+We have that the structural translation of the `PC_CELL` of `addRHS` into an ``EvmYul` state is `pc := intMap _Val5`.
+That is, mapping the value of `_Val5` into a `UInt256`.
+However, as per `(defn_Val5 : «_+Int_» PC_CELL 1 = some _Val5)` and the definition of `«_+Int_»` found in [`FuncInterface.lean`](../Interfaces/FuncInterface.lean),
+we know that the value of `_Val5` is `PC_CELL + 1`.
+
+Hence, we will state `pc := intMap («_+Int'_» PC_CELL 1)` instead of `pc := intMap _Val5`. For more details on `«_+Int_»`, `«_+Int'_»` or more functions visit [`FuncInterface.lean`](../Interfaces/FuncInterface.lean).
+
+### Final proofs
+
+The `EvmYul` functions that reflect the semantics of executing an opcode are `EVM.step` and `X` found in [`EvmYul/EVM/Semantics.lean`](https://github.com/NethermindEth/EVMYulLean/blob/main/EvmYul/EVM/Semantics.lean).
+Since the effects of opcode execution are separated between the two functions (for instance, `step` doesn't assign gas costs), we have
+one theorem for each function stating broadly the same.
+
+The statement is, for `f` being `EVM.step` or `X`
+> Given the `KEVM` prestate `LHS`, `f (stateMap LHS) = stateMap RHS`
+That is, mapping the `KEVM` prestate to `EvmYul` and executing either `EVM.step` or `X` gives us the mapped `KEVM` poststate.
+
+An number of additional hypothesis from the `defn_Val*` is added to each theorem. Revisiting and sanity-checking these hypothesis is worthwhile.
+The vast majority of them stem from the fact that [`KEVM` summaries](https://github.com/runtimeverification/evm-semantics/tree/master/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/summaries)
+assume that the `LHS` is a valid `KEVM` state. This means that conditions such as `PC_CELL < 2^256` are not enforced by the summaries and
+therefore need to be added as assumptions to obtain equivalence.
+
+These assumptions are present in the `KEVM` semantics, but they are enforced before triggering opcode execution.
+
+### Future work
+
+Notably, these proofs are only in one direction. Namely, we show that if `KEVM` computes something, `EvmYul` agrees with a
+translation of that computation. It remains to prove the converse. Namely, that `KEVM` agrees with a translation of what `EvmYul` computes.

--- a/EvmEquivalence/Equivalence/README.md
+++ b/EvmEquivalence/Equivalence/README.md
@@ -16,8 +16,8 @@ Given this, let's understand the anatomy of a Lean-generated rewrite rule.
 ### Anatomy of a rewrite rule
 
 Rewrite rules are comprised of
-- A left-hand side (lhs): a `KEVM` state prior to the execution of an opcode. Also known as prestate.
-- A right-hand side (rhs): a `KEVM` state derived from the execution of an opcode on the lhs. Also known as prestate.
+- A left-hand side (lhs): `KEVM` state prior to the execution of an opcode. Also known as prestate.
+- A right-hand side (rhs): `KEVM` state derived from the execution of an opcode on the lhs. Also known as prestate.
 - All the variables involved in the definition of the lhs and rhs.
 - All the conditions that give meaning to the variables present in the lhs and rhs.
 
@@ -32,7 +32,7 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
   ...                 -- A bunch more of variables
   (defn_Valn : f other_variables = some Valn) -- The meaning of the `_Valn` is explicitly given
   ...                 -- A bunch more of conditions
-  : Rewrites LHS RHS  -- Given all the conditions (`defn_Val*`) above we can state LHS => RHS
+  : Rewrites LHS RHS  -- Given all the conditions (`defn_Val*`) above, we can state LHS => RHS
 ```
 
 Here `LHS` and `RHS` are representations of the `KEVM` pre and post states with the appropriate structure given the `defn_Val*` conditions.
@@ -61,7 +61,7 @@ These theorems are mostly structural, especially the `opcodeLHS`. However, the `
 
 To exemplify what this means, consider `add_poststate_equiv` in [`AddEquivalence.lean`](./AddEquivalence.lean).
 
-We have that the structural translation of the `PC_CELL` of `addRHS` into an ``EvmYul` state is `pc := intMap _Val5`.
+We have that the structural translation of the `PC_CELL` of `addRHS` into an `EvmYul` state is `pc := intMap _Val5`.
 That is, mapping the value of `_Val5` into a `UInt256`.
 However, as per `(defn_Val5 : «_+Int_» PC_CELL 1 = some _Val5)` and the definition of `«_+Int_»` found in [`FuncInterface.lean`](../Interfaces/FuncInterface.lean),
 we know that the value of `_Val5` is `PC_CELL + 1`.
@@ -74,9 +74,9 @@ The `EvmYul` functions that reflect the semantics of executing an opcode are `EV
 Since the effects of opcode execution are separated between the two functions (for instance, `step` doesn't assign gas costs), we have
 one theorem for each function stating broadly the same.
 
-The statement is, for `f` being `EVM.step` or `X`
+The statement is, for `f` being `EVM.step` or `EVM.X`:
 > Given the `KEVM` prestate `LHS`, `f (stateMap LHS) = stateMap RHS`
-That is, mapping the `KEVM` prestate to `EvmYul` and executing either `EVM.step` or `X` gives us the mapped `KEVM` poststate.
+That is, mapping the `KEVM` prestate to `EvmYul` and executing either `EVM.step` or `EVM.X` gives us the mapped `KEVM` poststate.
 
 An number of additional hypothesis from the `defn_Val*` is added to each theorem. Revisiting and sanity-checking these hypothesis is worthwhile.
 The vast majority of them stem from the fact that [`KEVM` summaries](https://github.com/runtimeverification/evm-semantics/tree/master/kevm-pyk/src/kevm_pyk/kproj/evm-semantics/summaries)

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -1,0 +1,725 @@
+import EvmEquivalence.Summaries.SstoreSummary
+import EvmEquivalence.StateMap
+import EvmEquivalence.Interfaces.FuncInterface
+import EvmEquivalence.Interfaces.GasInterface
+import EvmEquivalence.Interfaces.EvmYulInterface
+
+open EvmYul
+open StateMap
+open KEVMInterface
+open SstoreSummary
+
+namespace SstoreOpcodeEquivalence
+
+def sstoreLHS
+  {ACCESSEDSTORAGE_CELL : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val20 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell} : SortGeneratedTopCell :=
+  { kevm := {
+      k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortBinStackOp SortMaybeOpCode) SortBinStackOp.SSTORE_EVM_BinStackOp))) K_CELL },
+      exitCode := _Gen34,
+      mode := _Gen35,
+      schedule := { val := SCHEDULE_CELL },
+      useGas := { val := USEGAS_CELL },
+      ethereum := {
+        evm := {
+          output := _Gen13,
+          statusCode := _Gen14,
+          callStack := _Gen15,
+          interimStates := _Gen16,
+          touchedAccounts := _Gen17,
+          callState := {
+            program := _Gen0,
+            jumpDests := _Gen1,
+            id := { val := (@inj SortInt SortAccount) ID_CELL },
+            caller := _Gen2,
+            callData := _Gen3,
+            callValue := _Gen4,
+            wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W0 (SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W1 WS) },
+            localMem := _Gen5,
+            pc := { val := PC_CELL },
+            gas := { val := (@inj SortInt SortGas) GAS_CELL },
+            memoryUsed := _Gen6,
+            callGas := _Gen7,
+            static := { val := false },
+            callDepth := _Gen8 },
+          versionedHashes := _Gen18,
+          substate := {
+            selfDestruct := _Gen9,
+            log := _Gen10,
+            refund := { val := REFUND_CELL },
+            accessedAccounts := _Gen11,
+            accessedStorage := { val := ACCESSEDSTORAGE_CELL },
+            createdAccounts := _Gen12 },
+          gasPrice := _Gen19,
+          origin := _Gen20,
+          blockhashes := _Gen21,
+          block := _Gen22 },
+        network := {
+          chainID := _Gen27,
+          accounts := { val := _Val20 },
+          txOrder := _Gen28,
+          txPending := _Gen29,
+          messages := _Gen30,
+          withdrawalsPending := _Gen31,
+          withdrawalsOrder := _Gen32,
+          withdrawals := _Gen33 } } },
+    generatedCounter := _DotVar0 }
+
+def sstoreRHS
+  { _Val39 _Val40 : SortMap}
+  { ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {_Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  {_Val34 _Val36 _Val37 _Val38 : SortSet}
+  {_Val35 : SortKItem} : SortGeneratedTopCell :=
+  { kevm := {
+      k := { val := K_CELL },
+      exitCode := _Gen34,
+      mode := _Gen35,
+      schedule := { val := SCHEDULE_CELL },
+      useGas := { val := true },
+      ethereum := {
+        evm := {
+          output := _Gen13,
+          statusCode := _Gen14,
+          callStack := _Gen15,
+          interimStates := _Gen16,
+          touchedAccounts := _Gen17,
+          callState := {
+            program := _Gen0,
+            jumpDests := _Gen1,
+            id := { val := (@inj SortInt SortAccount) ID_CELL },
+            caller := _Gen2,
+            callData := _Gen3,
+            callValue := _Gen4,
+            wordStack := { val := WS },
+            localMem := _Gen5,
+            pc := { val := _Val21 },
+            gas := { val := (@inj SortInt SortGas) _Val29 },
+            memoryUsed := _Gen6,
+            callGas := _Gen7,
+            static := { val := false },
+            callDepth := _Gen8 },
+          versionedHashes := _Gen18,
+          substate := {
+            selfDestruct := _Gen9,
+            log := _Gen10,
+            refund := { val := _Val33 },
+            accessedAccounts := _Gen11,
+            accessedStorage := { val := _Val39 },
+            createdAccounts := _Gen12 },
+          gasPrice := _Gen19,
+          origin := _Gen20,
+          blockhashes := _Gen21,
+          block := _Gen22 },
+        network := {
+          chainID := _Gen27,
+          accounts := { val := _Val42 },
+          txOrder := _Gen28,
+          txPending := _Gen29,
+          messages := _Gen30,
+          withdrawalsPending := _Gen31,
+          withdrawalsOrder := _Gen32,
+          withdrawals := _Gen33 } } },
+    generatedCounter := _DotVar0 }
+
+theorem rw_sstoreLHS_sstoreRHS
+  {ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  {_Val34 _Val36 _Val37 _Val38 : SortSet}
+  {_Val35 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : lookup STORAGE_CELL W0 = some _Val1)
+  (defn_Val2 : lookup ORIG_STORAGE_CELL W0 = some _Val2)
+  (defn_Val3 : Csstore SCHEDULE_CELL W1 _Val1 _Val2 = some _Val3)
+  (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
+  (defn_Val5 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val5)
+  (defn_Val6 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val6)
+  (defn_Val7 : kite _Val5 0 _Val6 = some _Val7)
+  (defn_Val8 : lookup STORAGE_CELL W0 = some _Val8)
+  (defn_Val9 : lookup ORIG_STORAGE_CELL W0 = some _Val9)
+  (defn_Val10 : Csstore SCHEDULE_CELL W1 _Val8 _Val9 = some _Val10)
+  (defn_Val11 : «_-Int_» GAS_CELL _Val10 = some _Val11)
+  (defn_Val12 : «_<=Int_» _Val7 _Val11 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<Int_» _Val13 GAS_CELL = some _Val14)
+  (defn_Val15 : _andBool_ _Val12 _Val14 = some _Val15)
+  (defn_Val16 : _andBool_ _Val4 _Val15 = some _Val16)
+  (defn_Val17 : _andBool_ _Val0 _Val16 = some _Val17)
+  (defn_Val18 : _andBool_ USEGAS_CELL _Val17 = some _Val18)
+  (defn_Val19 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := STORAGE_CELL },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val19)
+  (defn_Val20 : _AccountCellMap_ _Val19 _DotVar6 = some _Val20)
+  (defn_Val21 : «_+Int_» PC_CELL 1 = some _Val21)
+  (defn_Val22 : lookup STORAGE_CELL W0 = some _Val22)
+  (defn_Val23 : lookup ORIG_STORAGE_CELL W0 = some _Val23)
+  (defn_Val24 : Csstore SCHEDULE_CELL W1 _Val22 _Val23 = some _Val24)
+  (defn_Val25 : «_-Int_» GAS_CELL _Val24 = some _Val25)
+  (defn_Val26 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val26)
+  (defn_Val27 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val27)
+  (defn_Val28 : kite _Val26 0 _Val27 = some _Val28)
+  (defn_Val29 : «_-Int_» _Val25 _Val28 = some _Val29)
+  (defn_Val30 : lookup STORAGE_CELL W0 = some _Val30)
+  (defn_Val31 : lookup ORIG_STORAGE_CELL W0 = some _Val31)
+  (defn_Val32 : Rsstore SCHEDULE_CELL W1 _Val30 _Val31 = some _Val32)
+  (defn_Val33 : «_+Int_» REFUND_CELL _Val32 = some _Val33)
+  (defn_Val34 : «.Set» = some _Val34)
+  (defn_Val35 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val34) = some _Val35)
+  (defn_Val36 : «project:Set» (SortK.kseq _Val35 SortK.dotk) = some _Val36)
+  (defn_Val37 : SetItem ((@inj SortInt SortKItem) W0) = some _Val37)
+  (defn_Val38 : «_|Set__SET_Set_Set_Set» _Val36 _Val37 = some _Val38)
+  (defn_Val39 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val38) = some _Val39)
+  (defn_Val40 : «Map:update» STORAGE_CELL ((@inj SortInt SortKItem) W0) ((@inj SortInt SortKItem) W1) = some _Val40)
+  (defn_Val41 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := _Val40 },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val41)
+  (defn_Val42 : _AccountCellMap_ _Val41 _DotVar6 = some _Val42)
+  (req : _Val18 = true) :
+  Rewrites
+  (@sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  (@sstoreRHS  _Val39 _Val40  ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35) := by
+  apply (@Rewrites.SSTORE_SUMMARY_SSTORE_SUMMARY_1 ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL USEGAS_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35)
+  all_goals assumption
+
+theorem sstore_prestate_equiv
+  {ACCESSEDSTORAGE_CELL : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val20 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  (symState : EVM.State):
+  let lhs := @sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9
+  stateMap symState lhs =
+  {symState with
+    stack := (intMap W0) :: (intMap W1) :: wordStackMap WS
+    pc := intMap PC_CELL
+    gasAvailable := intMap GAS_CELL
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)},
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap (SortGeneratedTopCell.accessedStorage lhs)
+            refundBalance := intMap REFUND_CELL
+           }
+    returnData := _Gen13.val
+    accountMap := Axioms.SortAccountsCellMap lhs.accounts
+    } := by rfl
+
+-- Behavior of `Csstore`
+def Csstore_compute (value stor_val ostor_val : SortInt) : SortInt :=
+  if stor_val = value ∨ ¬ostor_val = stor_val then 100 else
+  if ostor_val = 0 then 20000 else 2900
+
+@[simp]
+theorem Csstore_def {value stor_val ostor_val : SortInt}:
+  Csstore SortSchedule.CANCUN_EVM value stor_val ostor_val =
+  some (Csstore_compute value stor_val ostor_val) := by
+  unfold Csstore GAS_FEES_Csstore_new
+  simp [Option.bind, IntEq_def, IntNEq_def, orBool_def]; rfl
+
+/--
+Remaining gas after deducting to `gas` the cost of executing `sstore`
+- `map` will be the accessed storage map
+- `value` is the stored value
+- `stor_val` is the current value in storage
+- `ostor_val` is the value from the origin storage
+- `acc` is the account in question
+- `key` is where the value will be stored
+
+The addition is because this whole expression is to be deducted from the
+current gas available
+ -/
+noncomputable def sstore_gas (map : SortMap) (value stor_val ostor_val acc key: SortInt) : SortInt :=
+  (Csstore_compute value stor_val ostor_val) + ite (inStorage_compute map acc key) 0 2100
+
+/--
+Computational content of `GAS_FEES_Rsstore_new`
+The function is named `rsstore` instead of `rsstore_new` because if the
+schedule is Cancun, `Rsstore` equates to this function
+-/
+def rsstore (new current original: SortInt) : SortInt :=
+  (if (¬current = new ∧ original = current) ∧ new = 0 then 4800
+  else
+    (if (¬current = new ∧ ¬original = current) ∧ ¬original = 0 then
+        if current = 0 then -4800 else if new = 0 then 4800 else 0
+      else 0) +
+      if ¬current = new ∧ original = new then (if original = 0 then 20000 else 2900) - 100 else 0)
+
+theorem rsstore_new_def {new current original} {sched} (h : sched = .CANCUN_EVM) :
+  GAS_FEES_Rsstore_new sched new current original = some (rsstore new current original) := by
+  unfold GAS_FEES_Rsstore_new rsstore; split; subst h
+  simp [Option.bind, IntEq_def, IntNEq_def, andBool_def, «_-Int_», «_+Int_»]
+
+/--
+`Rsstore` is `GAS_FEES_Rsstore_new` when schedule is `.CANCUN_EVM`
+ -/
+theorem rsstore_def {new current original} {sched} (h : sched = .CANCUN_EVM) :
+  Rsstore sched new current original = some (rsstore new current original) := by
+  unfold Rsstore GAS_FEES_Rsstore_new rsstore; split; subst h
+  simp [Option.bind, IntEq_def, IntNEq_def, andBool_def, «_-Int_», «_+Int_»]
+
+section Aᵣ_equivalence
+variable (gas gasCost : ℕ)
+variable (symStack : Stack UInt256)
+variable (symPc symGasAvailable symRefund key value : UInt256)
+variable (symExecLength : ℕ)
+variable (symReturnData symCode : ByteArray)
+variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
+variable (symAccounts : AccountMap)
+variable (symCodeOwner : AccountAddress)
+
+attribute [local simp] State.lookupAccount
+attribute [local simp] GasConstants.Rsclear
+attribute [local simp] GasConstants.Gsreset
+attribute [local simp] GasConstants.Gwarmaccess
+attribute [local simp] GasConstants.Gsset
+
+theorem Aᵣ_rsstore_eq {new /- current original -/} /- {sched} -/ {symState: EvmYul.State} /- (h : sched = .CANCUN_EVM) -/
+  -- Hypothesis linking `Aᵣ` and `rsstore`
+  /- (current_link : (symState.accountMap.find! symCodeOwner).storage.findD key ⟨0⟩ = intMap current)
+  (original_link : (symState.σ₀.find! symCodeOwner).storage.findD key ⟨0⟩ = intMap original) -/
+  (owner_exists : ¬Batteries.RBMap.find? symAccounts symCodeOwner = none):
+  let ss := {symState with
+             executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner},
+              accountMap := symAccounts,
+             substate := {symState.substate with
+                          accessedStorageKeys := symAccessedStorageKeys
+                          refundBalance := symRefund}
+              }
+  Aᵣ_sstore {ss with
+             accountMap := accountMap_sstore ss key (intMap new),
+             substate.accessedStorageKeys := accessedStorageKeys_sstore symState key,
+             substate.refundBalance := Aᵣ_sstore ss key (intMap new)} key (intMap new) = symRefund +
+             intMap (rsstore new (Int.ofNat ((symState.accountMap.find! symCodeOwner).storage.findD key ⟨0⟩).val.val) (Int.ofNat ((symState.σ₀.find! symCodeOwner).storage.findD key ⟨0⟩).val.val)) := by
+  simp [Aᵣ_sstore, rsstore]
+  split <;> split <;> try split <;> simp_all [State.lookupAccount] <;> aesop
+  . simp_all [Batteries.RBMap.find?_insert]
+    rename_i _ _ _ h _; split at h <;> simp_all
+  . rename_i n h; revert h
+    split <;> split <;> split
+    . aesop (add simp [UInt256.ofNat_toSigned])
+    . aesop (add simp [UInt256.ofNat_toSigned])
+    . aesop (add simp [UInt256.ofNat_toSigned])
+    . aesop (add simp [UInt256.ofNat_toSigned])
+    · sorry
+    · aesop (add simp [UInt256.ofNat_toSigned])
+    · sorry
+    · sorry
+  . sorry
+
+end Aᵣ_equivalence
+
+
+theorem sstore_poststate_equiv
+  {ACCESSEDSTORAGE_CELL /- STORAGE_CELL ORIG_STORAGE_CELL -/ _Val39 _Val40 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {_Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  {_Val34 _Val36 _Val37 _Val38 : SortSet}
+  {_Val35 : SortKItem}
+  (defn_Val21 : «_+Int_» PC_CELL 1 = some _Val21)
+  /- (defn_Val22 : lookup STORAGE_CELL W0 = some _Val22)
+  (defn_Val23 : lookup ORIG_STORAGE_CELL W0 = some _Val23) -/
+  (defn_Val24 : Csstore SCHEDULE_CELL W1 _Val22 _Val23 = some _Val24)
+  (defn_Val25 : «_-Int_» GAS_CELL _Val24 = some _Val25)
+  (defn_Val26 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val26)
+  (defn_Val27 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val27)
+  (defn_Val28 : kite _Val26 0 _Val27 = some _Val28)
+  (defn_Val29 : «_-Int_» _Val25 _Val28 = some _Val29)
+  (defn_Val33 : «_+Int_» REFUND_CELL _Val32 = some _Val33)
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (symState : EVM.State) :
+  let rhs := @sstoreRHS  _Val39 _Val40  ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35
+  stateMap symState rhs =
+  {symState with
+    stack := wordStackMap WS
+    pc := intMap («_+Int'_» PC_CELL 1)
+    gasAvailable := intMap (GAS_CELL - sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0)
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)},
+    accountMap := Axioms.SortAccountsCellMap rhs.accounts
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap  rhs.accessedStorage
+            -- TODO: Replace `_Val32` with a more explicit computation
+            -- such as `rsstore` above
+            refundBalance := intMap («_+Int'_» REFUND_CELL _Val32)
+           }
+    returnData := _Gen13.val
+  } := by
+  simp_all [sstoreRHS, stateMap, «_-Int_», plusInt_def, «_+Int_», ←inj_ID_CELL]
+  congr
+  aesop (add simp [inj, Inj.inj, sstore_gas]) (add safe (by linarith))
+
+theorem step_sstore_equiv
+  {ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  {_Val34 _Val36 _Val37 _Val38 : SortSet}
+  {_Val35 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : lookup STORAGE_CELL W0 = some _Val1)
+  (defn_Val2 : lookup ORIG_STORAGE_CELL W0 = some _Val2)
+  (defn_Val3 : Csstore SCHEDULE_CELL W1 _Val1 _Val2 = some _Val3)
+  (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
+  (defn_Val5 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val5)
+  (defn_Val6 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val6)
+  (defn_Val7 : kite _Val5 0 _Val6 = some _Val7)
+  (defn_Val8 : lookup STORAGE_CELL W0 = some _Val8)
+  (defn_Val9 : lookup ORIG_STORAGE_CELL W0 = some _Val9)
+  (defn_Val10 : Csstore SCHEDULE_CELL W1 _Val8 _Val9 = some _Val10)
+  (defn_Val11 : «_-Int_» GAS_CELL _Val10 = some _Val11)
+  (defn_Val12 : «_<=Int_» _Val7 _Val11 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<Int_» _Val13 GAS_CELL = some _Val14)
+  (defn_Val15 : _andBool_ _Val12 _Val14 = some _Val15)
+  (defn_Val16 : _andBool_ _Val4 _Val15 = some _Val16)
+  (defn_Val17 : _andBool_ _Val0 _Val16 = some _Val17)
+  (defn_Val18 : _andBool_ USEGAS_CELL _Val17 = some _Val18)
+  (defn_Val19 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := STORAGE_CELL },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val19)
+  (defn_Val20 : _AccountCellMap_ _Val19 _DotVar6 = some _Val20)
+  (defn_Val21 : «_+Int_» PC_CELL 1 = some _Val21)
+  (defn_Val22 : lookup STORAGE_CELL W0 = some _Val22)
+  (defn_Val23 : lookup ORIG_STORAGE_CELL W0 = some _Val23)
+  (defn_Val24 : Csstore SCHEDULE_CELL W1 _Val22 _Val23 = some _Val24)
+  (defn_Val25 : «_-Int_» GAS_CELL _Val24 = some _Val25)
+  (defn_Val26 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val26)
+  (defn_Val27 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val27)
+  (defn_Val28 : kite _Val26 0 _Val27 = some _Val28)
+  (defn_Val29 : «_-Int_» _Val25 _Val28 = some _Val29)
+  (defn_Val30 : lookup STORAGE_CELL W0 = some _Val30)
+  (defn_Val31 : lookup ORIG_STORAGE_CELL W0 = some _Val31)
+  (defn_Val32 : Rsstore SCHEDULE_CELL W1 _Val30 _Val31 = some _Val32)
+  (defn_Val33 : «_+Int_» REFUND_CELL _Val32 = some _Val33)
+  (defn_Val34 : «.Set» = some _Val34)
+  (defn_Val35 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val34) = some _Val35)
+  (defn_Val36 : «project:Set» (SortK.kseq _Val35 SortK.dotk) = some _Val36)
+  (defn_Val37 : SetItem ((@inj SortInt SortKItem) W0) = some _Val37)
+  (defn_Val38 : «_|Set__SET_Set_Set_Set» _Val36 _Val37 = some _Val38)
+  (defn_Val39 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val38) = some _Val39)
+  (defn_Val40 : «Map:update» STORAGE_CELL ((@inj SortInt SortKItem) W0) ((@inj SortInt SortKItem) W1) = some _Val40)
+  (defn_Val41 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := _Val40 },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val41)
+  (defn_Val42 : _AccountCellMap_ _Val41 _DotVar6 = some _Val42)
+  (req : _Val18 = true)
+  (symState : EVM.State)
+  -- needed for EVM.step
+  (gas gasCost : ℕ)
+  -- Necessary assumptions for equivalence
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (gasPos : 0 < gas)
+  (gavailEnough : sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0 ≤ GAS_CELL)
+  (gavailSmall : GAS_CELL < ↑UInt256.size)
+  (gasCostValue : gasCost = sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0)
+  (pcountSmall : PC_CELL + 1 < UInt256.size)
+  (pcountNonneg : 0 ≤ PC_CELL)
+  (W0ge0 : 0 ≤ W0)
+  (W1ge0 : 0 ≤ W1)
+  (ID_CELLSize : Int.toNat ID_CELL < AccountAddress.size):
+  EVM.step_sstore gas gasCost (stateMap symState (@sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
+  .ok (stateMap {symState with execLength := symState.execLength + 1} (@sstoreRHS  _Val39 _Val40  ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35)) := by
+  let acc : SortAccountCell := {
+          acctID := { val := ID_CELL },
+          balance := _Gen23,
+          code := _Gen24,
+          storage := { val := STORAGE_CELL },
+          origStorage := { val := ORIG_STORAGE_CELL },
+          transientStorage := _Gen25,
+          nonce := _Gen26 }
+  cases gas; contradiction
+  rw [sstore_prestate_equiv, EVM.step_sstore_summary] <;> try assumption
+  rw [sstoreLHS, sstore_poststate_equiv, sstoreRHS] <;> try congr
+  . simp only [accountMap_sstore, Aᵣ_sstore]
+    simp only [State.lookupAccount, SortGeneratedTopCell.accounts]
+    split
+    . rename_i _ _ owner; simp only [accountAddressMap.eq_def, inj_ID_CELL] at owner
+      rw [(Axioms.accountsCell_map_find? acc)] at owner <;> first | contradiction | congr
+    . rename_i _ ownerAcc findOwner
+      exact (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37
+      defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20 ownerAcc)
+  . simp [State.lookupAccount]
+    split
+    . rename_i _ _ owner
+      rw [(Axioms.accountsCell_map_find? acc)] at owner <;> first | contradiction | congr
+    . constructor
+      . /- Refund Cell -/
+        sorry
+      . rename_i _ ownerAcc findOwner
+        exact (Axioms.accessedStorageCell_map_insert defn_Val34 defn_Val35
+        defn_Val36 defn_Val37 defn_Val38 defn_Val39)
+  . rw [(UInt256.ofNat_toSigned gasCostValue), sstore_gas] at *
+    rw [cancun, Csstore_def, Option.some.injEq] at defn_Val10 defn_Val3
+    aesop (add safe (by rw [intMap_sub_dist])) (add simp [Csstore_compute])
+  . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
+
+end SstoreOpcodeEquivalence

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -471,8 +471,9 @@ theorem Aᵣ_rsstore_eq {new /- current original -/} /- {sched} -/ {symState: Ev
              accountMap := accountMap_sstore ss key (intMap new),
              substate.accessedStorageKeys := accessedStorageKeys_sstore symState key,
              substate.refundBalance := Aᵣ_sstore ss key (intMap new)} key (intMap new) = symRefund +
-             intMap (rsstore new (Int.ofNat ((symState.accountMap.find! symCodeOwner).storage.findD key ⟨0⟩).val.val) (Int.ofNat ((symState.σ₀.find! symCodeOwner).storage.findD key ⟨0⟩).val.val)) := by
-  simp [Aᵣ_sstore, rsstore]
+             intMap (rsstore new (Int.ofNat ((symState.accountMap.find! symCodeOwner).storage.findD key ⟨0⟩).val.val) (Int.ofNat ((symState.σ₀.find! symCodeOwner).storage.findD key ⟨0⟩).val.val)) := by sorry
+-- Commented to speed up
+/-   simp [Aᵣ_sstore, rsstore]
   split <;> split <;> try split <;> simp_all [State.lookupAccount] <;> aesop
   . simp_all [Batteries.RBMap.find?_insert]
     rename_i _ _ _ h _; split at h <;> simp_all
@@ -486,7 +487,7 @@ theorem Aᵣ_rsstore_eq {new /- current original -/} /- {sched} -/ {symState: Ev
     · aesop (add simp [UInt256.ofNat_toSigned])
     · sorry
     · sorry
-  . sorry
+  . sorry -/
 
 end Aᵣ_equivalence
 

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -1,8 +1,8 @@
 import EvmEquivalence.Summaries.SstoreSummary
-import EvmEquivalence.StateMap
-import EvmEquivalence.Interfaces.FuncInterface
-import EvmEquivalence.Interfaces.GasInterface
 import EvmEquivalence.Interfaces.EvmYulInterface
+import EvmEquivalence.Interfaces.GasInterface
+import EvmEquivalence.Interfaces.FuncInterface
+import EvmEquivalence.StateMap
 
 open EvmYul
 open StateMap

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -732,4 +732,178 @@ theorem step_sstore_equiv
   . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
   . aesop (add simp [ltInt_def, andBool_def]) (add safe (by linarith))
 
+theorem X_sstore_equiv
+  {ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortLogCell}
+  {_Gen11 : SortAccessedAccountsCell}
+  {_Gen12 : SortCreatedAccountsCell}
+  {_Gen13 : SortOutputCell}
+  {_Gen14 : SortStatusCodeCell}
+  {_Gen15 : SortCallStackCell}
+  {_Gen16 : SortInterimStatesCell}
+  {_Gen17 : SortTouchedAccountsCell}
+  {_Gen18 : SortVersionedHashesCell}
+  {_Gen19 : SortGasPriceCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortOriginCell}
+  {_Gen21 : SortBlockhashesCell}
+  {_Gen22 : SortBlockCell}
+  {_Gen23 : SortBalanceCell}
+  {_Gen24 : SortCodeCell}
+  {_Gen25 : SortTransientStorageCell}
+  {_Gen26 : SortNonceCell}
+  {_Gen27 : SortChainIDCell}
+  {_Gen28 : SortTxOrderCell}
+  {_Gen29 : SortTxPendingCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortMessagesCell}
+  {_Gen31 : SortWithdrawalsPendingCell}
+  {_Gen32 : SortWithdrawalsOrderCell}
+  {_Gen33 : SortWithdrawalsCell}
+  {_Gen34 : SortExitCodeCell}
+  {_Gen35 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortCallDepthCell}
+  {_Gen9 : SortSelfDestructCell}
+  {_Val34 _Val36 _Val37 _Val38 : SortSet}
+  {_Val35 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : lookup STORAGE_CELL W0 = some _Val1)
+  (defn_Val2 : lookup ORIG_STORAGE_CELL W0 = some _Val2)
+  (defn_Val3 : Csstore SCHEDULE_CELL W1 _Val1 _Val2 = some _Val3)
+  (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
+  (defn_Val5 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val5)
+  (defn_Val6 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val6)
+  (defn_Val7 : kite _Val5 0 _Val6 = some _Val7)
+  (defn_Val8 : lookup STORAGE_CELL W0 = some _Val8)
+  (defn_Val9 : lookup ORIG_STORAGE_CELL W0 = some _Val9)
+  (defn_Val10 : Csstore SCHEDULE_CELL W1 _Val8 _Val9 = some _Val10)
+  (defn_Val11 : «_-Int_» GAS_CELL _Val10 = some _Val11)
+  (defn_Val12 : «_<=Int_» _Val7 _Val11 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<Int_» _Val13 GAS_CELL = some _Val14)
+  (defn_Val15 : _andBool_ _Val12 _Val14 = some _Val15)
+  (defn_Val16 : _andBool_ _Val4 _Val15 = some _Val16)
+  (defn_Val17 : _andBool_ _Val0 _Val16 = some _Val17)
+  (defn_Val18 : _andBool_ USEGAS_CELL _Val17 = some _Val18)
+  (defn_Val19 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := STORAGE_CELL },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val19)
+  (defn_Val20 : _AccountCellMap_ _Val19 _DotVar6 = some _Val20)
+  (defn_Val21 : «_+Int_» PC_CELL 1 = some _Val21)
+  (defn_Val22 : lookup STORAGE_CELL W0 = some _Val22)
+  (defn_Val23 : lookup ORIG_STORAGE_CELL W0 = some _Val23)
+  (defn_Val24 : Csstore SCHEDULE_CELL W1 _Val22 _Val23 = some _Val24)
+  (defn_Val25 : «_-Int_» GAS_CELL _Val24 = some _Val25)
+  (defn_Val26 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val26)
+  (defn_Val27 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val27)
+  (defn_Val28 : kite _Val26 0 _Val27 = some _Val28)
+  (defn_Val29 : «_-Int_» _Val25 _Val28 = some _Val29)
+  (defn_Val30 : lookup STORAGE_CELL W0 = some _Val30)
+  (defn_Val31 : lookup ORIG_STORAGE_CELL W0 = some _Val31)
+  (defn_Val32 : Rsstore SCHEDULE_CELL W1 _Val30 _Val31 = some _Val32)
+  (defn_Val33 : «_+Int_» REFUND_CELL _Val32 = some _Val33)
+  (defn_Val34 : «.Set» = some _Val34)
+  (defn_Val35 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val34) = some _Val35)
+  (defn_Val36 : «project:Set» (SortK.kseq _Val35 SortK.dotk) = some _Val36)
+  (defn_Val37 : SetItem ((@inj SortInt SortKItem) W0) = some _Val37)
+  (defn_Val38 : «_|Set__SET_Set_Set_Set» _Val36 _Val37 = some _Val38)
+  (defn_Val39 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val38) = some _Val39)
+  (defn_Val40 : «Map:update» STORAGE_CELL ((@inj SortInt SortKItem) W0) ((@inj SortInt SortKItem) W1) = some _Val40)
+  (defn_Val41 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := _Val40 },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 } = some _Val41)
+  (defn_Val42 : _AccountCellMap_ _Val41 _DotVar6 = some _Val42)
+  (req : _Val18 = true)
+  (symState : EVM.State)
+  -- Necessary assumptions for equivalence
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (gavailEnough : sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0 ≤ GAS_CELL)
+  (gavailSmall : GAS_CELL < ↑UInt256.size)
+  /- (gasCostValue : gasCost = sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0) -/
+  (codeSstoreLHS : _Gen0 = ⟨⟨#[(0x55 : UInt8)]⟩⟩)
+  (codeSstoreRHS : _Gen24 = ⟨⟨⟨#[(0x55 : UInt8)]⟩⟩⟩)
+  (pcZero : PC_CELL = 0)
+  (key_pos : 0 ≤ W0)
+  (val_pos : 0 ≤ W1)
+  (ID_CELLSize : Int.toNat ID_CELL < AccountAddress.size)
+  -- TODO: Replace with a native measure for `SortWordStack` and
+  -- prove this assumption via an equality theorem stating that
+  -- `List.length (wordStackMap WS) = wordStackLength WS`
+  (stackOk: List.length (wordStackMap WS) < 1024)
+  -- This hypothesis is needed in order to have a successful run of `EVM.X`:
+  (callStipendGas : GasConstants.Gcallstipend < (intMap GAS_CELL).toNat)
+  :
+  EVM.X false (UInt256.toNat (intMap GAS_CELL)) (stateMap symState (@sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
+  .ok (.success (stateMap {symState with execLength := symState.execLength + 2} (@sstoreRHS  _Val39 _Val40  ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 ⟨.empty⟩ _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35)) .empty ) := by
+  let acc : SortAccountCell := {
+          acctID := { val := ID_CELL },
+          balance := _Gen23,
+          code := _Gen24,
+          storage := { val := STORAGE_CELL },
+          origStorage := { val := ORIG_STORAGE_CELL },
+          transientStorage := _Gen25,
+          nonce := _Gen26 }
+  let acc_updated : SortAccountCell := {
+    acctID := { val := ID_CELL },
+    balance := _Gen23,
+    code := _Gen24,
+    storage := { val := _Val40 },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := _Gen25,
+    nonce := _Gen26 }
+  rw [pcZero, codeSstoreLHS, codeSstoreRHS, sstore_prestate_equiv, sstore_poststate_equiv] <;> try assumption
+  simp
+  have pc_equiv : intMap 0 = UInt256.ofNat 0 := rfl
+  rw [pc_equiv, X_sstore_summary] <;> try assumption
+  . congr
+    . simp [State.lookupAccount, sstoreLHS, sstoreRHS]
+      simp [Axioms.accountsCell_map_find? acc (by eq_refl) defn_Val19 defn_Val20]
+      apply (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37 defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20 (accountMap acc))
+    . /- Refund Cell -/
+      sorry
+    . /- Gas Cell -/
+      rw [cancun, Csstore_def, Option.some.injEq] at defn_Val10 defn_Val3
+      simp [EVM.Csstore, sstoreLHS, sstoreRHS]
+      simp [GasConstants.Gwarmaccess, GasConstants.Gcoldsload, GasConstants.Gsset, GasConstants.Gsreset]
+      rw [intMap_sub_dist] <;> try assumption
+      . congr
+        conv =>
+        rhs
+        simp [intMap, UInt256.toSigned]
+        cases cg: (sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0) <;> try contradiction
+        next n =>
+          congr
+          simp [sstore_gas, Csstore_compute] at *
+          sorry
+        next =>
+          have fls := sstore_gas_pos ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0
+          rw [cg] at fls; contradiction
+      . aesop (add simp [sstore_gas, Csstore_compute]) (add safe (by omega))
+    . aesop (add simp [plusInt_def])
+  . /- We should have a theorem saying that `sstore_gas` and `Csstore` compute the same value -/
+    sorry
+
 end SstoreOpcodeEquivalence

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -709,14 +709,11 @@ theorem step_sstore_equiv
     omega
   rw [sstore_prestate_equiv, EVM.step_sstore_summary] <;> try assumption
   rw [sstoreLHS, sstore_poststate_equiv, sstoreRHS] <;> try congr
-  . simp only [accountMap_sstore, Aᵣ_sstore]
-    simp only [State.lookupAccount, SortGeneratedTopCell.accounts]
-    split
-    . rename_i _ _ owner; simp only [accountAddressMap.eq_def, inj_ID_CELL] at owner
-      rw [(Axioms.accountsCell_map_find? acc)] at owner <;> first | contradiction | congr
-    . rename_i _ ownerAcc findOwner
-      exact (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37
-      defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20 ownerAcc)
+  . simp only [accountMap_sstore, Aᵣ_sstore, State.lookupAccount]
+    simp only [SortGeneratedTopCell.accounts, accountAddressMap, inj_ID_CELL]
+    simp [(Axioms.accountsCell_map_find? acc (by eq_refl) defn_Val19 defn_Val20)]
+    exact (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37
+    defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20)
   . simp [State.lookupAccount]
     split
     . rename_i _ _ owner
@@ -882,7 +879,7 @@ theorem X_sstore_equiv
   . congr
     . simp [State.lookupAccount, sstoreLHS, sstoreRHS]
       simp [Axioms.accountsCell_map_find? acc (by eq_refl) defn_Val19 defn_Val20]
-      apply (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37 defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20 (accountMap acc))
+      apply (Axioms.accountsCell_map_insert defn_Val34 defn_Val35 defn_Val36 defn_Val37 defn_Val38 defn_Val40 defn_Val41 defn_Val42 defn_Val19 defn_Val20)
     . /- Refund Cell -/
       sorry
     . /- Gas Cell -/

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -730,5 +730,6 @@ theorem step_sstore_equiv
     rw [cancun, Csstore_def, Option.some.injEq] at defn_Val10 defn_Val3
     aesop (add safe (by rw [intMap_sub_dist])) (add simp [Csstore_compute])
   . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
+  . aesop (add simp [ltInt_def, andBool_def]) (add safe (by linarith))
 
 end SstoreOpcodeEquivalence

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -680,10 +680,9 @@ theorem step_sstore_equiv
   (req : _Val18 = true)
   (symState : EVM.State)
   -- needed for EVM.step
-  (gas gasCost : ℕ)
+  (gasCost : ℕ)
   -- Necessary assumptions for equivalence
   (cancun : SCHEDULE_CELL = .CANCUN_EVM)
-  (gasPos : 0 < gas)
   (gavailEnough : sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0 ≤ GAS_CELL)
   (gavailSmall : GAS_CELL < ↑UInt256.size)
   (gasCostValue : gasCost = sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0)
@@ -692,7 +691,7 @@ theorem step_sstore_equiv
   (W0ge0 : 0 ≤ W0)
   (W1ge0 : 0 ≤ W1)
   (ID_CELLSize : Int.toNat ID_CELL < AccountAddress.size):
-  EVM.step_sstore gas gasCost (stateMap symState (@sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
+  EVM.step_sstore (Int.toNat GAS_CELL) gasCost (stateMap symState (@sstoreLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val20 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
   .ok (stateMap {symState with execLength := symState.execLength + 1} (@sstoreRHS  _Val39 _Val40  ID_CELL _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 K_CELL SCHEDULE_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 WS _DotVar0 _DotVar6 _Val19 _Val20 _Val41 _Val42 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val34 _Val36 _Val37 _Val38 _Val35)) := by
   let acc : SortAccountCell := {
           acctID := { val := ID_CELL },
@@ -702,7 +701,11 @@ theorem step_sstore_equiv
           origStorage := { val := ORIG_STORAGE_CELL },
           transientStorage := _Gen25,
           nonce := _Gen26 }
-  cases gas; contradiction
+  cases cg: (Int.toNat GAS_CELL)
+  next =>
+    have fls := sstore_gas_pos ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0
+    have _ := Int.lt_of_lt_of_le fls gavailEnough
+    omega
   rw [sstore_prestate_equiv, EVM.step_sstore_summary] <;> try assumption
   rw [sstoreLHS, sstore_poststate_equiv, sstoreRHS] <;> try congr
   . simp only [accountMap_sstore, Aᵣ_sstore]

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -407,6 +407,10 @@ current gas available
 noncomputable def sstore_gas (map : SortMap) (value stor_val ostor_val acc key: SortInt) : SortInt :=
   (Csstore_compute value stor_val ostor_val) + ite (inStorage_compute map acc key) 0 2100
 
+theorem sstore_gas_pos (map : SortMap) (value stor_val ostor_val acc key: SortInt) :
+  0 < sstore_gas map value stor_val ostor_val acc key := by
+  aesop (add simp [sstore_gas, Csstore_compute])
+
 /--
 Computational content of `GAS_FEES_Rsstore_new`
 The function is named `rsstore` instead of `rsstore_new` because if the

--- a/EvmEquivalence/Equivalence/SstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SstoreEquivalence.lean
@@ -370,7 +370,8 @@ theorem sstore_prestate_equiv
     gasAvailable := intMap GAS_CELL
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)},
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)
+                  perm := true},
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap (SortGeneratedTopCell.accessedStorage lhs)
             refundBalance := intMap REFUND_CELL
@@ -553,7 +554,8 @@ theorem sstore_poststate_equiv
     gasAvailable := intMap (GAS_CELL - sstore_gas ACCESSEDSTORAGE_CELL W1 _Val22 _Val23 ID_CELL W0)
     executionEnv := {symState.executionEnv with
                   code := _Gen0.val,
-                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)},
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)
+                  perm := true},
     accountMap := Axioms.SortAccountsCellMap rhs.accounts
     substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap  rhs.accessedStorage

--- a/EvmEquivalence/Interfaces/Axioms.lean
+++ b/EvmEquivalence/Interfaces/Axioms.lean
@@ -1,0 +1,22 @@
+import EvmEquivalence.Interfaces.EvmYulInterface
+import EvmEquivalence.KEVM2Lean.Sorts
+
+open EvmYul
+
+/-
+This module contains current axioms used in the equivalence work.
+The reason of needing this axioms is to have placeholders for pending work. Such as:
+1. Missing implementation of the Lean 4 K-generated code
+2. Missing reasoning-suitable interfaces for the EvmYul model
+ -/
+namespace Axioms
+
+axiom SortAccountsCellMap : SortAccountsCell → AccountMap
+
+axiom SortAccessedStorageCellMap : SortAccessedStorageCell → Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp
+
+axiom SortStorageCellMap : SortStorageCell → Storage
+
+axiom SortTransientStorageCellMap : SortTransientStorageCell → Storage
+
+end Axioms

--- a/EvmEquivalence/Interfaces/EvmYulInterface.lean
+++ b/EvmEquivalence/Interfaces/EvmYulInterface.lean
@@ -15,6 +15,8 @@ set_option linter.deprecated false
 variable {n : ℕ}
 variable {p : ℤ}
 
+-- Conversions
+
 theorem val_eq (h : n < UInt256.size): ↑(UInt256.ofNat n).1 = n := by
   aesop (add simp [UInt256.ofNat, Id.run, Fin.ofNat])
         (add safe (by omega))
@@ -25,6 +27,11 @@ theorem ofNat_eq: UInt256.ofNat n = ⟨Fin.ofNat n⟩ := by
 theorem ofNat_toNat (n_le_size : n < UInt256.size) :
   (UInt256.ofNat n).toNat = n := by
   aesop (add simp [UInt256.ofNat, UInt256.toNat, Id.run, dbgTrace, Fin.ofNat])
+
+theorem ofNat_toSigned {n : ℕ} {p : ℤ} (h : ↑n = p) :
+  UInt256.ofNat n = .toSigned p := by aesop
+
+-- Arithmetic
 
 @[simp]
 theorem sub_0 {n : UInt256} : n - .ofNat 0 = n := by

--- a/EvmEquivalence/Interfaces/FuncInterface.lean
+++ b/EvmEquivalence/Interfaces/FuncInterface.lean
@@ -133,4 +133,15 @@ theorem sizeWordStack_def {ws : SortWordStack} :
   sizeWordStackAux ws 0 = some (List.length (wordStackMap ws)) :=
   wsLength_eq_length_wordStackMap ▸ sizeWordStackIsSome
 
+
+-- Behavior of `AccountCellMapItem`
+/--
+Note that this function is dependent on the current implementation of `SortAccountCellMap`
+
+The current implementation is `List (SortAcctIDCell × SortAccountCell)` but
+this might change in the future
+-/
+def accountCellMapItem_def (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap :=
+  some (⟨[(x0, x1)]⟩)
+
 end KEVMInterface

--- a/EvmEquivalence/Interfaces/FuncInterface.lean
+++ b/EvmEquivalence/Interfaces/FuncInterface.lean
@@ -82,6 +82,10 @@ end -/
 axiom Keq_def (k₁ k₂ : SortK) : «_==K_» k₁ k₂ = some (k₁ == k₂)
 axiom Kneq_def (k₁ k₂ : SortK) : «_=/=K_» k₁ k₂ = some (k₁ != k₂)
 
+-- Behavior of `==Int` and `=/=Int`
+axiom IntEq_def (n m : SortInt) : «_==Int_» n m = some (n == m)
+axiom IntNEq_def (n m : SortInt) : «_=/=Int_» n m = some (n != m)
+
 -- Behavior of `_orBool_` and `_andBool_`
 axiom orBool_def (b₁ b₂ : SortBool) : _orBool_ b₁ b₂ = some (b₁ || b₂)
 axiom andBool_def (b₁ b₂ : SortBool) : _andBool_ b₁ b₂ = some (b₁ && b₂)
@@ -135,6 +139,7 @@ theorem sizeWordStack_def {ws : SortWordStack} :
 
 
 -- Behavior of `AccountCellMapItem`
+-- TODO: Complete or delete
 /--
 Note that this function is dependent on the current implementation of `SortAccountCellMap`
 
@@ -143,5 +148,47 @@ this might change in the future
 -/
 def accountCellMapItem_def (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap :=
   some (⟨[(x0, x1)]⟩)
+
+-- Behavior of `kite`
+@[simp]
+theorem kite_def {SortSort : Type} (cnd : SortBool) (true_branch false_branch: SortSort) :
+  kite cnd true_branch false_branch = ite cnd true_branch false_branch := by
+  aesop
+
+-- Behavior of K's `in_keys` function
+-- NOTE: These functions depend on the dummy implementation as maps
+-- being `List (Key × Value)`
+def keys {K V : Type} (l : List (K × V)) : List K :=
+  List.map (λ pair => pair.1) l
+
+def inKeys_compute (map : SortMap) (key : SortInt) : Bool :=
+  List.elem (inj key) (keys map.coll)
+
+@[simp]
+axiom Axioms.inKeys_def (map : SortMap) (key : SortInt) :
+  «_in_keys(_)_MAP_Bool_KItem_Map» (inj ((inj key) : SortAccount)) map =
+  some (inKeys_compute map key)
+
+-- Behavior of `#inStorage`
+noncomputable def inStorage_compute (map : SortMap) (acc key : SortInt) : Bool :=
+  match «Map:lookup» map (inj ((@inj SortInt SortAccount) acc)) with
+  | none => false
+  | some a => match «#inStorageAux1» a key with
+    | none => false
+    | some b => if inKeys_compute map acc then b else false
+
+@[simp]
+theorem inStorage_def {ACCESSEDSTORAGE_CELL : SortMap} {ID_CELL W0 : SortInt} :
+  «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some (inStorage_compute ACCESSEDSTORAGE_CELL ID_CELL W0) := by
+  aesop (add simp [«#inStorage», _dbb1f9e, _8d90a32, Option.bind, inStorage_compute])
+
+-- Helper theorems
+
+@[simp]
+theorem inj_ID_CELL (ID_CELL : SortInt) : @inj SortInt SortAccount instInjSortIntSortAccount ID_CELL = .inj_SortInt ID_CELL := rfl
+
+@[simp]
+theorem accountAddressIsSome (n : ℕ) (size : n < AccountAddress.size) : AccountAddress.ofNat n = ⟨n, size⟩ := by
+  simp [AccountAddress.ofNat, Fin.ofNat]; aesop
 
 end KEVMInterface

--- a/EvmEquivalence/Interfaces/GasInterface.lean
+++ b/EvmEquivalence/Interfaces/GasInterface.lean
@@ -14,6 +14,7 @@ attribute [local simp] Keq_def Kneq_def
 attribute [local simp] orBool_def andBool_def notBool_def
 
 variable (const : SortScheduleConst)
+variable (flag : SortScheduleFlag)
 
 -- These should be temporary axioms
 instance: DecidableEq SortK := fun
@@ -306,5 +307,188 @@ theorem cancun_def :
   := by
   simp [«_<_>_SCHEDULE_Int_ScheduleConst_Schedule»]
   cases const <;> simp
+
+@[local simp]
+theorem flag_default_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .DEFAULT_EVM =
+  match flag with
+  | .Gemptyisnonexistent_SCHEDULE_ScheduleFlag     => false
+  | .Ghasaccesslist_SCHEDULE_ScheduleFlag          => false
+  | .Ghasbasefee_SCHEDULE_ScheduleFlag             => false
+  | .Ghasbeaconroot_SCHEDULE_ScheduleFlag          => false
+  | .Ghasblobbasefee_SCHEDULE_ScheduleFlag         => false
+  | .Ghasblobhash_SCHEDULE_ScheduleFlag            => false
+  | .Ghaschainid_SCHEDULE_ScheduleFlag             => false
+  | .Ghascreate2_SCHEDULE_ScheduleFlag             => false
+  | .Ghasdirtysstore_SCHEDULE_ScheduleFlag         => false
+  | .Ghaseip6780_SCHEDULE_ScheduleFlag             => false
+  | .Ghasextcodehash_SCHEDULE_ScheduleFlag         => false
+  | .Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag     => false
+  | .Ghasmcopy_SCHEDULE_ScheduleFlag               => false
+  | .Ghasprevrandao_SCHEDULE_ScheduleFlag          => false
+  | .Ghaspushzero_SCHEDULE_ScheduleFlag            => false
+  | .Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag   => false
+  | .Ghasreturndata_SCHEDULE_ScheduleFlag          => false
+  | .Ghasrevert_SCHEDULE_ScheduleFlag              => false
+  | .Ghasselfbalance_SCHEDULE_ScheduleFlag         => false
+  | .Ghasshift_SCHEDULE_ScheduleFlag               => false
+  | .Ghassstorestipend_SCHEDULE_ScheduleFlag       => false
+  | .Ghasstaticcall_SCHEDULE_ScheduleFlag          => false
+  | .Ghastransient_SCHEDULE_ScheduleFlag           => false
+  | .Ghaswarmcoinbase_SCHEDULE_ScheduleFlag        => false
+  | .Ghaswithdrawals_SCHEDULE_ScheduleFlag         => false
+  | .Gselfdestructnewaccount_SCHEDULE_ScheduleFlag => false
+  | .Gstaticcalldepth_SCHEDULE_ScheduleFlag        => true
+  | .Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag => true := by
+  simp_flag; cases flag <;> simp
+
+@[local simp]
+theorem flag_homestead_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .HOMESTEAD_EVM =
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .DEFAULT_EVM := by
+  simp_flag; cases flag <;> simp_flag
+
+/- theorem ksek_beq (kitem₁ kitem₂ : SortKItem) (kseq₁ kseq₂ : SortK) :
+  (SortK.kseq kitem₁ kseq₁ == SortK.kseq kitem₂ kseq₂) = false ↔
+  kitem₁ ≠ kitem₂ ∨ kseq₁ ≠ kseq₂ := by
+  aesop (add safe (by cases ceq: decide (kitem₁ = kitem₂))) -/
+
+@[local simp]
+theorem flag_tangerine_whistle_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .TANGERINE_WHISTLE_EVM =
+  match flag with
+  | .Gselfdestructnewaccount_SCHEDULE_ScheduleFlag => true
+  | .Gstaticcalldepth_SCHEDULE_ScheduleFlag        => false
+  | flag =>
+    «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .HOMESTEAD_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_spurious_dragon_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .SPURIOUS_DRAGON_EVM =
+  match flag with
+  | .Gemptyisnonexistent_SCHEDULE_ScheduleFlag     => true
+  | .Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag => false
+  | flag =>
+    «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .TANGERINE_WHISTLE_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_byzantyum_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .BYZANTIUM_EVM =
+  match flag with
+  | .Ghasrevert_SCHEDULE_ScheduleFlag     => true
+  | .Ghasreturndata_SCHEDULE_ScheduleFlag => true
+  | .Ghasstaticcall_SCHEDULE_ScheduleFlag => true
+  | flag =>
+    «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .SPURIOUS_DRAGON_EVM  := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_constantinople_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .CONSTANTINOPLE_EVM =
+  match flag with
+  | .Ghasshift_SCHEDULE_ScheduleFlag       => true
+  | .Ghasdirtysstore_SCHEDULE_ScheduleFlag => true
+  | .Ghascreate2_SCHEDULE_ScheduleFlag     => true
+  | .Ghasextcodehash_SCHEDULE_ScheduleFlag => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .BYZANTIUM_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_petersburg_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .PETERSBURG_EVM =
+  match flag with
+  | .Ghasdirtysstore_SCHEDULE_ScheduleFlag => false
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .CONSTANTINOPLE_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_istambul_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .ISTANBUL_EVM =
+  match flag with
+  | .Ghasselfbalance_SCHEDULE_ScheduleFlag   => true
+  | .Ghasdirtysstore_SCHEDULE_ScheduleFlag   => true
+  | .Ghassstorestipend_SCHEDULE_ScheduleFlag => true
+  | .Ghaschainid_SCHEDULE_ScheduleFlag       => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .PETERSBURG_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_berlin_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .BERLIN_EVM =
+  match flag with
+  | .Ghasaccesslist_SCHEDULE_ScheduleFlag => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .ISTANBUL_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_london_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .LONDON_EVM =
+  match flag with
+  | .Ghasbasefee_SCHEDULE_ScheduleFlag           => true
+  | .Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .BERLIN_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_merge_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .MERGE_EVM =
+  match flag with
+  | .Ghasprevrandao_SCHEDULE_ScheduleFlag => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .LONDON_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[local simp]
+theorem flag_shanghai_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .SHANGHAI_EVM =
+  match flag with
+  | .Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag => true
+  | .Ghaspushzero_SCHEDULE_ScheduleFlag        => true
+  | .Ghaswarmcoinbase_SCHEDULE_ScheduleFlag    => true
+  | .Ghaswithdrawals_SCHEDULE_ScheduleFlag     => true
+  | flag =>
+      «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .MERGE_EVM := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
+
+@[simp]
+theorem flag_cancun_def :
+  «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .CANCUN_EVM =
+  match flag with
+  | .Gemptyisnonexistent_SCHEDULE_ScheduleFlag     => true
+  | .Ghasaccesslist_SCHEDULE_ScheduleFlag          => true
+  | .Ghasbasefee_SCHEDULE_ScheduleFlag             => true
+  | .Ghasbeaconroot_SCHEDULE_ScheduleFlag          => true
+  | .Ghasblobbasefee_SCHEDULE_ScheduleFlag         => true
+  | .Ghasblobhash_SCHEDULE_ScheduleFlag            => true
+  | .Ghaschainid_SCHEDULE_ScheduleFlag             => true
+  | .Ghascreate2_SCHEDULE_ScheduleFlag             => true
+  | .Ghasdirtysstore_SCHEDULE_ScheduleFlag         => true
+  | .Ghaseip6780_SCHEDULE_ScheduleFlag             => true
+  | .Ghasextcodehash_SCHEDULE_ScheduleFlag         => true
+  | .Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag     => true
+  | .Ghasmcopy_SCHEDULE_ScheduleFlag               => true
+  | .Ghasprevrandao_SCHEDULE_ScheduleFlag          => true
+  | .Ghaspushzero_SCHEDULE_ScheduleFlag            => true
+  | .Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag   => true
+  | .Ghasreturndata_SCHEDULE_ScheduleFlag          => true
+  | .Ghasrevert_SCHEDULE_ScheduleFlag              => true
+  | .Ghasselfbalance_SCHEDULE_ScheduleFlag         => true
+  | .Ghasshift_SCHEDULE_ScheduleFlag               => true
+  | .Ghassstorestipend_SCHEDULE_ScheduleFlag       => true
+  | .Ghasstaticcall_SCHEDULE_ScheduleFlag          => true
+  | .Ghastransient_SCHEDULE_ScheduleFlag           => true
+  | .Ghaswarmcoinbase_SCHEDULE_ScheduleFlag        => true
+  | .Ghaswithdrawals_SCHEDULE_ScheduleFlag         => true
+  | .Gselfdestructnewaccount_SCHEDULE_ScheduleFlag => true
+  | .Gstaticcalldepth_SCHEDULE_ScheduleFlag        => false
+  | .Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag => false := by
+  simp_flag; cases flag <;> simp_flag <;> simp [inj, Inj.inj]
 
 end GasInterface

--- a/EvmEquivalence/Interfaces/GasInterface.lean
+++ b/EvmEquivalence/Interfaces/GasInterface.lean
@@ -348,11 +348,6 @@ theorem flag_homestead_def :
   «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .DEFAULT_EVM := by
   simp_flag; cases flag <;> simp_flag
 
-/- theorem ksek_beq (kitem₁ kitem₂ : SortKItem) (kseq₁ kseq₂ : SortK) :
-  (SortK.kseq kitem₁ kseq₁ == SortK.kseq kitem₂ kseq₂) = false ↔
-  kitem₁ ≠ kitem₂ ∨ kseq₁ ≠ kseq₂ := by
-  aesop (add safe (by cases ceq: decide (kitem₁ = kitem₂))) -/
-
 @[local simp]
 theorem flag_tangerine_whistle_def :
   «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» flag .TANGERINE_WHISTLE_EVM =

--- a/EvmEquivalence/Interfaces/GasInterface.lean
+++ b/EvmEquivalence/Interfaces/GasInterface.lean
@@ -93,7 +93,7 @@ theorem sched_default_def :
   | .maxInitCodeSize_SCHEDULE_ScheduleConst        => some 0
   | .Ginitcodewordcost_SCHEDULE_ScheduleConst      => some 0
   | .Rmaxquotient_SCHEDULE_ScheduleConst           => some 2
-  | .Gpointeval_SCHEDULE_ScheduleConst => some 0
+  | .Gpointeval_SCHEDULE_ScheduleConst             => some 0
   := by
   simp_schedule1; cases const <;> simp_schedule2
 
@@ -128,8 +128,8 @@ theorem sched_tangerine_whistle_def :
 theorem sched_spurious_dragon_def :
   «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» const .SPURIOUS_DRAGON_EVM =
   match const with
-  | .Gexpbyte_SCHEDULE_ScheduleConst      => some 50
-  | .maxCodeSize_SCHEDULE_ScheduleConst   => some 24576
+  | .Gexpbyte_SCHEDULE_ScheduleConst    => some 50
+  | .maxCodeSize_SCHEDULE_ScheduleConst => some 24576
   | const => «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» const .TANGERINE_WHISTLE_EVM := by
   simp_schedule1; cases const <;> simp_schedule2
 

--- a/EvmEquivalence/Interfaces/GasInterface.lean
+++ b/EvmEquivalence/Interfaces/GasInterface.lean
@@ -31,7 +31,7 @@ theorem neq_gconst_fls (c₁ c₂ : SortScheduleConst) : c₁ ≠ c₂ →
 @[local simp]
 theorem neq_gconst_true (c₁ c₂ : SortScheduleConst) : c₁ ≠ c₂ →
   (SortK.kseq (inj c₁) SortK.dotk != SortK.kseq (inj c₂) SortK.dotk) := by
-  simp [ne_eq, bne_iff_ne, SortK.kseq.injEq, and_true, inj, Inj.inj]
+    aesop (add simp [bne])
 
 set_option maxRecDepth 100000
 

--- a/EvmEquivalence/Interfaces/README.md
+++ b/EvmEquivalence/Interfaces/README.md
@@ -6,5 +6,33 @@ This folder contains interfaces to reason with the EvmYul and KEVM models.
 
 - [`EvmYulInterface`](./EvmYulInterface.lean): Interface for the EvmYul model
 - [`FuncInterface`](./FuncInterface.lean): Interface for dealing with generated KEVM functions
-- [`GasInterface`](./GasInterface.lean): Interface for the `«_<_>_SCHEDULE_Int_ScheduleConst_Schedule»` function
+- [`GasInterface`](./GasInterface.lean): Interface for the `«_<_>_SCHEDULE_Int_ScheduleConst_Schedule»` and `«_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule»` functions
 - [`Tactics`](./Tactics.lean): Tactics to help with the [`GasInterface.lean`](./GasInterface.lean) proofs
+- [`Axioms`](./Axioms.lean): Axiomatization of the state mapping
+
+## Axiomatic mapping
+
+The file [`Axioms.lean`](./Axioms.lean) declares the exsistence of functions that convert `KEVM` maps into `EvmYul` ones.
+
+The reason for this axiomatization is twofold.
+
+1. Unimplemented maps in the K Lean 4 backend:
+   K maps are currently undefined in the Lean 4 generated code. We still have to come up with a suitable-enough implementation of K
+   maps that preserve the original semantics.
+
+   Note that this is tricky given that K maps have to be defined inside of a `mutual` inductive block, which limits the options
+   available to prevent crashing with Lean's positivity checker.
+   A clear disadvantage of this is that we cannot (apparently) use `FinMap` as our map implementation.
+2. Non reasoning-friendly maps in the `EvmYul` model:
+   Currently, the `EvmYul` model is more geared towards execution than reasoning.
+   This means that the map representation is not the most optimal for reasoning, and a more reasoning-friendly interface could be
+   provided in the future. This is an argument in favor of not commiting (yet) to a K map representation tailored to play well with
+   the current `EvmYul` maps, but this argument could change in the future.
+
+## Axioms as pre-theorems
+
+Given that we're axiomatizing part of the state translation, properties on the axiomatic parts need to be provided.
+How the axiomatic parts of the state mapping are _needed_ to behave is laid out in the `Axioms` namespace at the end of the [`StateMap.lean`](../StateMap.lean) file.
+
+These axioms establish the correspondence between the mapped data and the functions in the `EvmYul` map implementation.
+Once we have a clear implementation of K maps in Lean, all these axioms should become theorems.

--- a/EvmEquivalence/Interfaces/Tactics.lean
+++ b/EvmEquivalence/Interfaces/Tactics.lean
@@ -5,8 +5,9 @@ This file contains tactics to agilize and compress certain repetitive proofs
 import EvmEquivalence.KEVM2Lean.Func
 
 -- Tactics to perform lengthy simps for schedule
-syntax "simp_schedule1"     : tactic
-syntax "simp_schedule2"     : tactic
+syntax "simp_schedule1" : tactic
+syntax "simp_schedule2" : tactic
+syntax "simp_flag"      : tactic
 
 -- The reason for having separate simps is that otherwise
 -- Lean performs too many operations at once
@@ -120,3 +121,78 @@ macro_rules
               (try simp [SCHEDULE_maxCodeSizeDragon]);
               (try simp [SCHEDULE_maxInitCodeSizeDefault]);
               (try simp [SCHEDULE_maxInitCodeSizeShanghai]))
+
+macro_rules
+| `(tactic| simp_flag) =>
+  `(tactic| (try simp [«_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule»]);
+            (try simp [SCHEDULE_GemptyisnonexistentDefault]);
+            (try simp [SCHEDULE_GemptyisnonexistentDragon]);
+            (try simp [SCHEDULE_GhasaccesslistDefault]);
+            (try simp [SCHEDULE_GhasbasefeeDefault]);
+            (try simp [SCHEDULE_GhasbasefeeLondon]);
+            (try simp [SCHEDULE_GhasbeaconrootCancun]);
+            (try simp [SCHEDULE_GhasbeaconrootDefault]);
+            (try simp [SCHEDULE_GhasblobbasefeeCancun]);
+            (try simp [SCHEDULE_GhasblobbasefeeDefault]);
+            (try simp [SCHEDULE_GhasblobhashCancun]);
+            (try simp [SCHEDULE_GhasblobhashDefault]);
+            (try simp [SCHEDULE_GhaschainidDefault]);
+            (try simp [SCHEDULE_GhaschainidIstanbul]);
+            (try simp [SCHEDULE_Ghascreate2Constantinople]);
+            (try simp [SCHEDULE_Ghascreate2Default]);
+            (try simp [SCHEDULE_GhasdirtysstoreConstantinople]);
+            (try simp [SCHEDULE_GhasdirtysstoreDefault]);
+            (try simp [SCHEDULE_GhasdirtysstoreIstanbul]);
+            (try simp [SCHEDULE_GhasdirtysstorePetersburg]);
+            (try simp [SCHEDULE_Ghaseip6780Cancun]);
+            (try simp [SCHEDULE_Ghaseip6780Default]);
+            (try simp [SCHEDULE_GhasextcodehashConstantinople]);
+            (try simp [SCHEDULE_GhasextcodehashDefault]);
+            (try simp [SCHEDULE_GhasmaxinitcodesizeDefault]);
+            (try simp [SCHEDULE_GhasmaxinitcodesizeShanghai]);
+            (try simp [SCHEDULE_GhasmcopyCancun]);
+            (try simp [SCHEDULE_GhasmcopyDefault]);
+            (try simp [SCHEDULE_GhasprevrandaoDefault]);
+            (try simp [SCHEDULE_GhasprevrandaoMerge]);
+            (try simp [SCHEDULE_GhaspushzeroDefault]);
+            (try simp [SCHEDULE_GhaspushzeroShanghai]);
+            (try simp [SCHEDULE_GhasrejectedfirstbyteDefault]);
+            (try simp [SCHEDULE_GhasrejectedfirstbyteLondon]);
+            (try simp [SCHEDULE_GhasreturndataByzantium]);
+            (try simp [SCHEDULE_GhasreturndataDefault]);
+            (try simp [SCHEDULE_GhasrevertByzantium]);
+            (try simp [SCHEDULE_GhasrevertDefault]);
+            (try simp [SCHEDULE_GhasselfbalanceDefault]);
+            (try simp [SCHEDULE_GhasselfbalanceIstanbul]);
+            (try simp [SCHEDULE_GhasshiftConstantinople]);
+            (try simp [SCHEDULE_GhasshiftDefault]);
+            (try simp [SCHEDULE_GhassstorestipendDefault]);
+            (try simp [SCHEDULE_GhassstorestipendIstanbul]);
+            (try simp [SCHEDULE_GhasstaticcallByzantium]);
+            (try simp [SCHEDULE_GhasstaticcallDefault]);
+            (try simp [SCHEDULE_GhastransientCancun]);
+            (try simp [SCHEDULE_GhastransientDefault]);
+            (try simp [SCHEDULE_GhaswarmcoinbaseDefault]);
+            (try simp [SCHEDULE_GhaswarmcoinbaseShanghai]);
+            (try simp [SCHEDULE_GhaswithdrawalsDefault]);
+            (try simp [SCHEDULE_GhaswithdrawalsShanghai]);
+            (try simp [SCHEDULE_GselfdestructnewaccountDefault]);
+            (try simp [SCHEDULE_GselfdestructnewaccountTangerine]);
+            (try simp [SCHEDULE_GstaticcalldepthDefault]);
+            (try simp [SCHEDULE_GstaticcalldepthTangerine]);
+            (try simp [SCHEDULE_GzerovaluenewaccountgasDefault]);
+            (try simp [SCHEDULE_GzerovaluenewaccountgasDragon]);
+            (try simp [SCHEDULE_SCHEDFLAGBerlin]);
+            (try simp [SCHEDULE_SCHEDFLAGByzantium]);
+            (try simp [SCHEDULE_SCHEDFLAGCancun]);
+            (try simp [SCHEDULE_SCHEDFLAGConstantinople]);
+            (try simp [SCHEDULE_SCHEDFLAGDragon]);
+            (try simp [SCHEDULE_SCHEDFLAGFrontier]);
+            (try simp [SCHEDULE_SCHEDFLAGHomestead]);
+            (try simp [SCHEDULE_SCHEDFLAGIstanbul]);
+            (try simp [SCHEDULE_SCHEDFLAGLondon]);
+            (try simp [SCHEDULE_SCHEDFLAGMerge]);
+            (try simp [SCHEDULE_SCHEDFLAGPetersburg]);
+            (try simp [SCHEDULE_SCHEDFLAGShanghai]);
+            (try simp [SCHEDULE_SCHEDFLAGTangerine]);
+            (try simp [SCHEDULE_hasaccesslistBerlin]))

--- a/EvmEquivalence/KEVM2Lean/Func.lean
+++ b/EvmEquivalence/KEVM2Lean/Func.lean
@@ -1,208 +1,555 @@
 import EvmEquivalence.KEVM2Lean.Inj
 import EvmEquivalence.KEVM2Lean.ScheduleOrdering
 
-axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
+def _17ebc68 : SortBool → Option SortBool
+  | false => some true
+  | _ => none
 
-def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
-  | _, _ => none
-
-def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
-  | _, _ => none
-
-def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GsloadIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 800
-  | _, _ => none
-
-def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
-  | _, _ => none
-
-def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
-  | _, _ => none
-
-def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
-  | _, _ => none
+axiom _modInt_ (x0 : SortInt) (x1 : SortInt) : Option SortInt
 
 def SCHEDULE_GhighDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Ghigh_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
   | _, _ => none
 
-def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
-  | _, _ => none
-
-def _17ebc68 : SortBool → Option SortBool
-  | false => some true
-  | _ => none
-
-def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
-  | _, _ => none
-
-def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
-  | _, _ => none
-
-def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
-  | _, _ => none
-
-def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
-  | _, _ => none
-
-def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
-  | _, _ => none
-
-def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
-  | _, _ => none
-
-def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_RbDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000000000000000000
-  | _, _ => none
-
-def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
-  | _, _ => none
-
-def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
-  | _, _ => none
-
-def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
-  | _, _ => none
-
-def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
-  | _, _ => none
-
-def _5b9db8d : SortBool → SortBool → Option SortBool
-  | true, B => some B
-  | _, _ => none
-
-axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
-
-def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
-  | _, _ => none
-
-def SCHEDULE_GbalanceTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 400
-  | _, _ => none
-
-def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
-  | _, _ => none
-
-def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_GtxdatazeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatazero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4
-  | _, _ => none
-
-def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
+def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
   | _, _ => none
 
 def SCHEDULE_GmemoryDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
   | _, _ => none
 
-def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
+def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
   | _, _ => none
 
-def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
+def SCHEDULE_GhassstorestipendIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
   | _, _ => none
 
-def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
+  | _, _ => none
+
+axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
+
+def SCHEDULE_GhasselfbalanceDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstorePetersburg : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.PETERSBURG_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasrevertDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasrevertByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaswithdrawalsDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def _991a329 : SortBool → SortBool → Option SortBool
+  | false, B => some B
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Cancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def _7174452 : SortBool → SortBool → Option SortBool
+  | true, _Gen0 => some true
+  | _, _ => none
+
+def SCHEDULE_GhasstaticcallByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmcopyCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasshiftConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrejectedfirstbyteLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasrejectedfirstbyteDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Constantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmaxinitcodesizeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GemptyisnonexistentDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GemptyisnonexistentDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasreturndataDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaschainidDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GselfdestructnewaccountTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaschainidIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasprevrandaoMerge : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.MERGE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaspushzeroDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasstaticcallDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhassstorestipendDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasmcopyDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaswarmcoinbaseShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobhashCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GstaticcalldepthTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaspushzeroShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasaccesslistDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
 def _53fc758 : SortBool → Option SortBool
   | true => some false
   | _ => none
 
-def _991a329 : SortBool → SortBool → Option SortBool
-  | false, B => some B
+def SCHEDULE_GhasreturndataByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaswithdrawalsShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GselfdestructnewaccountDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhastransientDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasprevrandaoDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhastransientCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbasefeeLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasselfbalanceIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GstaticcalldepthDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_hasaccesslistBerlin : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.BERLIN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmaxinitcodesizeShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasshiftDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobhashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaswarmcoinbaseDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _5b9db8d : SortBool → SortBool → Option SortBool
+  | true, B => some B
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
+  | _, _ => none
+
+axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
+
+def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+axiom «.AccountCellMap» : Option SortAccountCellMap
+
+def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
+  | _, _ => none
+
+def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
+  | _, _ => none
+
+def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GbalanceTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 400
+  | _, _ => none
+
+def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
+  | _, _ => none
+
+def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+  | _, _ => none
+
+def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
+  | _, _ => none
+
+def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
+  | _, _ => none
+
+def SCHEDULE_RbDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000000000000000000
+  | _, _ => none
+
+def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
+  | _, _ => none
+
+def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
+  | _, _ => none
+
+def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
+  | _, _ => none
+
+def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GsloadIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 800
+  | _, _ => none
+
+def SCHEDULE_GtxdatazeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatazero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
+  | _, _ => none
+
+def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+  | _, _ => none
+
+def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
+  | _, _ => none
+
+def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
+  | _, _ => none
+
+def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
+  | _, _ => none
+
+def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
+  | _, _ => none
+
+def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
+  | _, _ => none
+
+def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
+  | _, _ => none
+
+def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
+  | _, _ => none
+
+def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
+  | _, _ => none
+
+def SCHEDULE_GextcodesizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GcoldaccountaccessBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2600
+  | _, _ => none
+
+def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
+  | _, _ => none
+
+def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
+  | _, _ => none
+
+def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
+  | _, _ => none
+
+def _1ff8f4d {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
+  | C, B1, _Gen0 => do
+    guard C
+    return B1
+
+def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
+  | _, _ => none
+
+def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
   | _, _ => none
 
 def SCHEDULE_GexpDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gexp_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+  | _, _ => none
+
+def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+axiom «_==Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
+
+def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
+  | _, _ => none
+
+def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
+  | _, _ => none
+
+def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
+  | _, _ => none
+
+def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
+  | _, _ => none
+
+def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
   | _, _ => none
 
 def SCHEDULE_maxCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
@@ -213,197 +560,124 @@ def SCHEDULE_GfroundDefault : SortScheduleConst → SortSchedule → Option Sort
   | SortScheduleConst.Gfround_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
   | _, _ => none
 
-def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
-  | _, _ => none
-
-def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
-  | _, _ => none
-
-def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
-  | _, _ => none
-
-def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
-  | _, _ => none
-
-def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GcoldaccountaccessBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2600
-  | _, _ => none
-
-def SCHEDULE_GtxdatanonzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 68
-  | _, _ => none
-
-def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
-  | _, _ => none
-
-def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
-  | _, _ => none
-
-def _7174452 : SortBool → SortBool → Option SortBool
-  | true, _Gen0 => some true
-  | _, _ => none
-
-def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
-  | _, _ => none
-
-def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
-  | _, _ => none
-
-def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
+def SCHEDULE_GquaddivisorBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 3
   | _, _ => none
 
 def _61fbef3 : SortBool → SortBool → Option SortBool
   | false, _Gen0 => some false
   | _, _ => none
 
-def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
+def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
   | _, _ => none
 
-def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
-  | _, _ => none
-
-def SCHEDULE_GquaddivisorBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
-  | _, _ => none
-
-def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
   | _, _ => none
 
 def SCHEDULE_GquaddivisorDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
   | _, _ => none
 
-def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
-  | _, _ => none
-
-def SCHEDULE_GextcodesizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
 def SCHEDULE_GlogtopicDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Glogtopic_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
   | _, _ => none
 
+def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
+  | _, _ => none
+
+def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GtxdatanonzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 68
+  | _, _ => none
+
+def _a3e3b07 : SortKItem → SortInt → Option SortBool
+  | _Gen0, _Gen1 => some false
+
 axiom «_|->_» (x0 : SortKItem) (x1 : SortKItem) : Option SortMap
 
-axiom «.AccountCellMap» : Option SortAccountCellMap
+axiom «Map:lookupOrDefault» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortKItem
 
-axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
+axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
 
-axiom WithdrawalCellMapItem (x0 : SortWithdrawalIDCell) (x1 : SortWithdrawalCell) : Option SortWithdrawalCellMap
+def _432e4e6 : SortSet → SortInt → Option SortBool
+  | _Gen0, _Gen1 => some false
 
-axiom ListItem (x0 : SortKItem) : Option SortList
-
-axiom «.Map» : Option SortMap
-
-axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
-
-axiom «_<Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
-
-axiom _modInt_ (x0 : SortInt) (x1 : SortInt) : Option SortInt
-
-axiom SetItem (x0 : SortKItem) : Option SortSet
-
-axiom «.List» : Option SortList
+axiom «Set:in» (x0 : SortKItem) (x1 : SortSet) : Option SortBool
 
 def _75897fa : SortWordStack → SortInt → Option SortInt
   | SortWordStack.«.WordStack_EVM-TYPES_WordStack», SIZE => some SIZE
   | _, _ => none
 
-axiom «.MessageCellMap» : Option SortMessageCellMap
-
-axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
-
-axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
-
-axiom MessageCellMapItem (x0 : SortMsgIDCell) (x1 : SortMessageCell) : Option SortMessageCellMap
-
-axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
-
 axiom «.Set» : Option SortSet
 
-axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
+def _0e7f507 : SortK → Option SortSet
+  | SortK.kseq (SortKItem.inj_SortSet K) SortK.dotk => some K
+  | _ => none
+
+axiom «_in_keys(_)_MAP_Bool_KItem_Map» (x0 : SortKItem) (x1 : SortMap) : Option SortBool
+
+def _92664aa : SortK → Option SortBool
+  | SortK.kseq (SortKItem.inj_SortInt Int) SortK.dotk => some true
+  | _ => none
+
+def _105572a : SortK → Option SortBool
+  | K => some false
 
 axiom _MessageCellMap_ (x0 : SortMessageCellMap) (x1 : SortMessageCellMap) : Option SortMessageCellMap
 
-def SCHEDULE_RbConstantinople : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.CONSTANTINOPLE_EVM => do
-    let _Val0 <- «_*Int_» 2 1000000000000000000
+axiom «Set:difference» (x0 : SortSet) (x1 : SortSet) : Option SortSet
+
+axiom «Map:update» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortMap
+
+axiom «_<Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
+
+axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
+
+axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
+
+def _8d90a32 : SortMap → SortAccount → SortInt → Option SortBool
+  | _Gen0, _Gen1, _Gen2 => some false
+
+axiom «.Map» : Option SortMap
+
+axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
+
+axiom «Map:lookup» (x0 : SortMap) (x1 : SortKItem) : Option SortKItem
+
+axiom «.MessageCellMap» : Option SortMessageCellMap
+
+axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
+
+axiom MessageCellMapItem (x0 : SortMsgIDCell) (x1 : SortMessageCell) : Option SortMessageCellMap
+
+axiom ListItem (x0 : SortKItem) : Option SortList
+
+axiom «.List» : Option SortList
+
+axiom SetItem (x0 : SortKItem) : Option SortSet
+
+axiom WithdrawalCellMapItem (x0 : SortWithdrawalIDCell) (x1 : SortWithdrawalCell) : Option SortWithdrawalCellMap
+
+axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
+
+noncomputable def _85aa67b : SortInt → Option SortInt
+  | I => do
+    let _Val0 <- _modInt_ I 115792089237316195423570985008687907853269984665640564039457584007913129639936
     return _Val0
-  | _, _ => none
+
+def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
+
+def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
 
 def SCHEDULE_RbByzantium : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.BYZANTIUM_EVM => do
@@ -411,16 +685,26 @@ def SCHEDULE_RbByzantium : SortScheduleConst → SortSchedule → Option SortInt
     return _Val0
   | _, _ => none
 
-def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
-
-def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
+def SCHEDULE_RbConstantinople : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.CONSTANTINOPLE_EVM => do
+    let _Val0 <- «_*Int_» 2 1000000000000000000
+    return _Val0
+  | _, _ => none
 
 def _andBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_5b9db8d x0 x1) <|> (_61fbef3 x0 x1)
 
-noncomputable def _85aa67b : SortInt → Option SortInt
-  | I => do
-    let _Val0 <- _modInt_ I 115792089237316195423570985008687907853269984665640564039457584007913129639936
-    return _Val0
+noncomputable def «EVM_TYPES_#lookup_some» : SortMap → SortInt → Option SortInt
+  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
+    | some ([SortKItem.inj_SortInt VAL], _M) => do
+      let _Val0 <- _modInt_ VAL 115792089237316195423570985008687907853269984665640564039457584007913129639936
+      return _Val0
+    | _ => none
+
+noncomputable def _42ba953 : SortSet → SortInt → Option SortBool
+  | KEYS, KEY => do
+    let _Val0 <- «Set:in» ((@inj SortInt SortKItem) KEY) KEYS
+    guard _Val0
+    return true
 
 mutual
   def _432555e : SortWordStack → SortInt → Option SortInt
@@ -433,18 +717,242 @@ mutual
   def sizeWordStackAux (x0 : SortWordStack) (x1 : SortInt) : Option SortInt := (_432555e x0 x1) <|> (_75897fa x0 x1)
 end
 
+def «project:Set» (x0 : SortK) : Option SortSet := _0e7f507 x0
+
+def isInt (x0 : SortK) : Option SortBool := (_92664aa x0) <|> (_105572a x0)
+
+noncomputable def _c384edb : SortSet → SortSet → Option SortSet
+  | S1, S2 => do
+    let _Val0 <- «Set:difference» S2 S1
+    let _Val1 <- _Set_ S1 _Val0
+    return _Val1
+
+noncomputable def chop (x0 : SortInt) : Option SortInt := _85aa67b x0
+
+-- Necessary to have the following `mutual` block passing without a `decreasing_by` proof
+attribute [local simp] SortScheduleFlag.toNat SortSchedule.toNat
+
+mutual
+  noncomputable def SCHEDULE_SCHEDFLAGTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.TANGERINE_WHISTLE_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- notBool_ _Val2
+      let _Val4 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.HOMESTEAD_EVM
+      guard _Val3
+      return _Val4
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.CONSTANTINOPLE_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val4 <- _orBool_ _Val2 _Val3
+      let _Val5 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val6 <- _orBool_ _Val4 _Val5
+      let _Val7 <- notBool_ _Val6
+      let _Val8 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.BYZANTIUM_EVM
+      guard _Val7
+      return _Val8
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGHomestead : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.HOMESTEAD_EVM => do
+      let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.DEFAULT_EVM
+      return _Val0
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.SHANGHAI_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val4 <- _orBool_ _Val2 _Val3
+      let _Val5 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val6 <- _orBool_ _Val4 _Val5
+      let _Val7 <- notBool_ _Val6
+      let _Val8 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.MERGE_EVM
+      guard _Val7
+      return _Val8
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGPetersburg : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.PETERSBURG_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- notBool_ _Val0
+      let _Val2 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.CONSTANTINOPLE_EVM
+      guard _Val1
+      return _Val2
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.BYZANTIUM_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val4 <- _orBool_ _Val2 _Val3
+      let _Val5 <- notBool_ _Val4
+      let _Val6 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.SPURIOUS_DRAGON_EVM
+      guard _Val5
+      return _Val6
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.ISTANBUL_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val4 <- _orBool_ _Val2 _Val3
+      let _Val5 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val6 <- _orBool_ _Val4 _Val5
+      let _Val7 <- notBool_ _Val6
+      let _Val8 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.PETERSBURG_EVM
+      guard _Val7
+      return _Val8
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGDragon : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.SPURIOUS_DRAGON_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- notBool_ _Val2
+      let _Val4 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.TANGERINE_WHISTLE_EVM
+      guard _Val3
+      return _Val4
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGMerge : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.MERGE_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- notBool_ _Val0
+      let _Val2 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.LONDON_EVM
+      guard _Val1
+      return _Val2
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGFrontier : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.FRONTIER_EVM => do
+      let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.DEFAULT_EVM
+      return _Val0
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» (x0 : SortScheduleFlag) (x1 : SortSchedule) : Option SortBool := (SCHEDULE_GemptyisnonexistentDefault x0 x1) <|> (SCHEDULE_GemptyisnonexistentDragon x0 x1) <|> (SCHEDULE_GhasaccesslistDefault x0 x1) <|> (SCHEDULE_GhasbasefeeDefault x0 x1) <|> (SCHEDULE_GhasbasefeeLondon x0 x1) <|> (SCHEDULE_GhasbeaconrootCancun x0 x1) <|> (SCHEDULE_GhasbeaconrootDefault x0 x1) <|> (SCHEDULE_GhasblobbasefeeCancun x0 x1) <|> (SCHEDULE_GhasblobbasefeeDefault x0 x1) <|> (SCHEDULE_GhasblobhashCancun x0 x1) <|> (SCHEDULE_GhasblobhashDefault x0 x1) <|> (SCHEDULE_GhaschainidDefault x0 x1) <|> (SCHEDULE_GhaschainidIstanbul x0 x1) <|> (SCHEDULE_Ghascreate2Constantinople x0 x1) <|> (SCHEDULE_Ghascreate2Default x0 x1) <|> (SCHEDULE_GhasdirtysstoreConstantinople x0 x1) <|> (SCHEDULE_GhasdirtysstoreDefault x0 x1) <|> (SCHEDULE_GhasdirtysstoreIstanbul x0 x1) <|> (SCHEDULE_GhasdirtysstorePetersburg x0 x1) <|> (SCHEDULE_Ghaseip6780Cancun x0 x1) <|> (SCHEDULE_Ghaseip6780Default x0 x1) <|> (SCHEDULE_GhasextcodehashConstantinople x0 x1) <|> (SCHEDULE_GhasextcodehashDefault x0 x1) <|> (SCHEDULE_GhasmaxinitcodesizeDefault x0 x1) <|> (SCHEDULE_GhasmaxinitcodesizeShanghai x0 x1) <|> (SCHEDULE_GhasmcopyCancun x0 x1) <|> (SCHEDULE_GhasmcopyDefault x0 x1) <|> (SCHEDULE_GhasprevrandaoDefault x0 x1) <|> (SCHEDULE_GhasprevrandaoMerge x0 x1) <|> (SCHEDULE_GhaspushzeroDefault x0 x1) <|> (SCHEDULE_GhaspushzeroShanghai x0 x1) <|> (SCHEDULE_GhasrejectedfirstbyteDefault x0 x1) <|> (SCHEDULE_GhasrejectedfirstbyteLondon x0 x1) <|> (SCHEDULE_GhasreturndataByzantium x0 x1) <|> (SCHEDULE_GhasreturndataDefault x0 x1) <|> (SCHEDULE_GhasrevertByzantium x0 x1) <|> (SCHEDULE_GhasrevertDefault x0 x1) <|> (SCHEDULE_GhasselfbalanceDefault x0 x1) <|> (SCHEDULE_GhasselfbalanceIstanbul x0 x1) <|> (SCHEDULE_GhasshiftConstantinople x0 x1) <|> (SCHEDULE_GhasshiftDefault x0 x1) <|> (SCHEDULE_GhassstorestipendDefault x0 x1) <|> (SCHEDULE_GhassstorestipendIstanbul x0 x1) <|> (SCHEDULE_GhasstaticcallByzantium x0 x1) <|> (SCHEDULE_GhasstaticcallDefault x0 x1) <|> (SCHEDULE_GhastransientCancun x0 x1) <|> (SCHEDULE_GhastransientDefault x0 x1) <|> (SCHEDULE_GhaswarmcoinbaseDefault x0 x1) <|> (SCHEDULE_GhaswarmcoinbaseShanghai x0 x1) <|> (SCHEDULE_GhaswithdrawalsDefault x0 x1) <|> (SCHEDULE_GhaswithdrawalsShanghai x0 x1) <|> (SCHEDULE_GselfdestructnewaccountDefault x0 x1) <|> (SCHEDULE_GselfdestructnewaccountTangerine x0 x1) <|> (SCHEDULE_GstaticcalldepthDefault x0 x1) <|> (SCHEDULE_GstaticcalldepthTangerine x0 x1) <|> (SCHEDULE_GzerovaluenewaccountgasDefault x0 x1) <|> (SCHEDULE_GzerovaluenewaccountgasDragon x0 x1) <|> (SCHEDULE_SCHEDFLAGBerlin x0 x1) <|> (SCHEDULE_SCHEDFLAGByzantium x0 x1) <|> (SCHEDULE_SCHEDFLAGCancun x0 x1) <|> (SCHEDULE_SCHEDFLAGConstantinople x0 x1) <|> (SCHEDULE_SCHEDFLAGDragon x0 x1) <|> (SCHEDULE_SCHEDFLAGFrontier x0 x1) <|> (SCHEDULE_SCHEDFLAGHomestead x0 x1) <|> (SCHEDULE_SCHEDFLAGIstanbul x0 x1) <|> (SCHEDULE_SCHEDFLAGLondon x0 x1) <|> (SCHEDULE_SCHEDFLAGMerge x0 x1) <|> (SCHEDULE_SCHEDFLAGPetersburg x0 x1) <|> (SCHEDULE_SCHEDFLAGShanghai x0 x1) <|> (SCHEDULE_SCHEDFLAGTangerine x0 x1) <|> (SCHEDULE_hasaccesslistBerlin x0 x1)
+  termination_by (x1.toNat, x0.toNat + 1)
+
+  noncomputable def SCHEDULE_SCHEDFLAGBerlin : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.BERLIN_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- notBool_ _Val0
+      let _Val2 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.ISTANBUL_EVM
+      guard _Val1
+      return _Val2
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGLondon : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.LONDON_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- notBool_ _Val2
+      let _Val4 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.BERLIN_EVM
+      guard _Val3
+      return _Val4
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+
+  noncomputable def SCHEDULE_SCHEDFLAGCancun : SortScheduleFlag → SortSchedule → Option SortBool
+    | SCHEDFLAG, SortSchedule.CANCUN_EVM => do
+      let _Val0 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val1 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val2 <- _orBool_ _Val0 _Val1
+      let _Val3 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val4 <- _orBool_ _Val2 _Val3
+      let _Val5 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val6 <- _orBool_ _Val4 _Val5
+      let _Val7 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val8 <- _orBool_ _Val6 _Val7
+      let _Val9 <- «_==K_» (SortK.kseq ((@inj SortScheduleFlag SortKItem) SCHEDFLAG) SortK.dotk) (SortK.kseq ((@inj SortScheduleFlag SortKItem) SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag) SortK.dotk)
+      let _Val10 <- _orBool_ _Val8 _Val9
+      let _Val11 <- notBool_ _Val10
+      let _Val12 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SCHEDFLAG SortSchedule.SHANGHAI_EVM
+      guard _Val11
+      return _Val12
+    | _, _ => none
+    termination_by sc s => (s.toNat, sc.toNat)
+end
+
+noncomputable def _4de6e05 : SortInt → SortInt → Option SortBool
+  | I1, I2 => do
+    let _Val0 <- «_==Int_» I1 I2
+    let _Val1 <- notBool_ _Val0
+    return _Val1
+
+noncomputable def «EVM_TYPES_#lookup_none» : SortMap → SortInt → Option SortInt
+  | M, KEY => do
+    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortInt SortKItem) KEY) M
+    let _Val1 <- notBool_ _Val0
+    guard _Val1
+    return 0
+
 noncomputable def _bccaba7 : SortK → SortK → Option SortBool
   | K1, K2 => do
     let _Val0 <- «_==K_» K1 K2
     let _Val1 <- notBool_ _Val0
     return _Val1
 
-noncomputable def chop (x0 : SortInt) : Option SortInt := _85aa67b x0
+def _2f3f58a {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
+  | C, _Gen0, B2 => do
+    let _Val0 <- notBool_ C
+    guard _Val0
+    return B2
+
+noncomputable def «#inStorageAux2» (x0 : SortSet) (x1 : SortInt) : Option SortBool := (_42ba953 x0 x1) <|> (_432e4e6 x0 x1)
+
+noncomputable def «EVM_TYPES_#lookup_notInt» : SortMap → SortInt → Option SortInt
+  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
+    | some ([VAL], _M) => do
+      let _Val0 <- isInt (SortK.kseq VAL SortK.dotk)
+      let _Val1 <- notBool_ _Val0
+      guard _Val1
+      return 0
+    | _ => none
+
+noncomputable def «_|Set__SET_Set_Set_Set» (x0 : SortSet) (x1 : SortSet) : Option SortSet := _c384edb x0 x1
+
+noncomputable def «_=/=Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool := _4de6e05 x0 x1
 
 noncomputable def «_=/=K_» (x0 : SortK) (x1 : SortK) : Option SortBool := _bccaba7 x0 x1
 
+def kite {SortSort : Type} (x0 : SortBool) (x1 : SortSort) (x2 : SortSort) : Option SortSort := (_1ff8f4d x0 x1 x2) <|> (_2f3f58a x0 x1 x2)
+
+noncomputable def _c44ca69 : SortKItem → SortInt → Option SortBool
+  | SortKItem.inj_SortSet KEYS, KEY => do
+    let _Val0 <- «#inStorageAux2» KEYS KEY
+    return _Val0
+  | _, _ => none
+
+noncomputable def lookup (x0 : SortMap) (x1 : SortInt) : Option SortInt := («EVM_TYPES_#lookup_none» x0 x1) <|> («EVM_TYPES_#lookup_notInt» x0 x1) <|> («EVM_TYPES_#lookup_some» x0 x1)
+
 -- Necessary to have the following `mutual` block passing without a `decreasing_by` proof
-attribute [local simp] Prod.lex_def SortScheduleConst.toNat SortSchedule.toNat
+attribute [local simp] SortScheduleConst.toNat
 
 mutual
   noncomputable def SCHEDULE_GsstoreresetBerlin : SortScheduleConst → SortSchedule → Option SortInt
@@ -657,3 +1165,96 @@ mutual
     | _, _ => none
   termination_by sc s => (s.toNat, sc.toNat)
 end
+
+noncomputable def «#inStorageAux1» (x0 : SortKItem) (x1 : SortInt) : Option SortBool := (_c44ca69 x0 x1) <|> (_a3e3b07 x0 x1)
+
+noncomputable def GAS_FEES_Rsstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- «_=/=Int_» CURR NEW
+    let _Val2 <- «_==Int_» ORIG CURR
+    let _Val3 <- _andBool_ _Val1 _Val2
+    let _Val4 <- «_==Int_» NEW 0
+    let _Val5 <- _andBool_ _Val3 _Val4
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- «_=/=Int_» CURR NEW
+    let _Val8 <- «_=/=Int_» ORIG CURR
+    let _Val9 <- _andBool_ _Val7 _Val8
+    let _Val10 <- «_=/=Int_» ORIG 0
+    let _Val11 <- _andBool_ _Val9 _Val10
+    let _Val12 <- «_==Int_» CURR 0
+    let _Val13 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
+    let _Val14 <- «_-Int_» 0 _Val13
+    let _Val15 <- «_==Int_» NEW 0
+    let _Val16 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
+    let _Val17 <- kite _Val15 _Val16 0
+    let _Val18 <- kite _Val12 _Val14 _Val17
+    let _Val19 <- kite _Val11 _Val18 0
+    let _Val20 <- «_=/=Int_» CURR NEW
+    let _Val21 <- «_==Int_» ORIG NEW
+    let _Val22 <- _andBool_ _Val20 _Val21
+    let _Val23 <- «_==Int_» ORIG 0
+    let _Val24 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val25 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val26 <- kite _Val23 _Val24 _Val25
+    let _Val27 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
+    let _Val28 <- «_-Int_» _Val26 _Val27
+    let _Val29 <- kite _Val22 _Val28 0
+    let _Val30 <- «_+Int_» _Val19 _Val29
+    let _Val31 <- kite _Val5 _Val6 _Val30
+    guard _Val0
+    return _Val31
+
+noncomputable def GAS_FEES_Csstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- «_==Int_» CURR NEW
+    let _Val2 <- «_=/=Int_» ORIG CURR
+    let _Val3 <- _orBool_ _Val1 _Val2
+    let _Val4 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
+    let _Val5 <- «_==Int_» ORIG 0
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val8 <- kite _Val5 _Val6 _Val7
+    let _Val9 <- kite _Val3 _Val4 _Val8
+    guard _Val0
+    return _Val9
+
+noncomputable def GAS_FEES_Rsstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, _ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- notBool_ _Val0
+    let _Val2 <- «_=/=Int_» CURR 0
+    let _Val3 <- «_==Int_» NEW 0
+    let _Val4 <- _andBool_ _Val2 _Val3
+    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
+    let _Val6 <- kite _Val4 _Val5 0
+    guard _Val1
+    return _Val6
+
+noncomputable def GAS_FEES_Csstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, _ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- notBool_ _Val0
+    let _Val2 <- «_==Int_» CURR 0
+    let _Val3 <- «_=/=Int_» NEW 0
+    let _Val4 <- _andBool_ _Val2 _Val3
+    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- kite _Val4 _Val5 _Val6
+    guard _Val1
+    return _Val7
+
+noncomputable def _dbb1f9e : SortMap → SortAccount → SortInt → Option SortBool
+  | TS, ACCT, KEY => do
+    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortAccount SortKItem) ACCT) TS
+    let _Val1 <- «Map:lookup» TS ((@inj SortAccount SortKItem) ACCT)
+    let _Val2 <- «#inStorageAux1» _Val1 KEY
+    guard _Val0
+    return _Val2
+
+noncomputable def Rsstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Rsstore_new x0 x1 x2 x3) <|> (GAS_FEES_Rsstore_old x0 x1 x2 x3)
+
+noncomputable def Csstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Csstore_new x0 x1 x2 x3) <|> (GAS_FEES_Csstore_old x0 x1 x2 x3)
+
+noncomputable def «#inStorage» (x0 : SortMap) (x1 : SortAccount) (x2 : SortInt) : Option SortBool := (_dbb1f9e x0 x1 x2) <|> (_8d90a32 x0 x1 x2)

--- a/EvmEquivalence/KEVM2Lean/Inj.lean
+++ b/EvmEquivalence/KEVM2Lean/Inj.lean
@@ -1,75 +1,21 @@
 import EvmEquivalence.KEVM2Lean.Sorts
 
-instance : Inj SortChainIDCell SortKItem where
-  inj := SortKItem.inj_SortChainIDCell
+instance : Inj SortGeneratedCounterCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedCounterCell
   retr
-    | SortKItem.inj_SortChainIDCell x => some x
+    | SortKItem.inj_SortGeneratedCounterCell x => some x
     | _ => none
 
-instance : Inj SortPreviousHashCell SortKItem where
-  inj := SortKItem.inj_SortPreviousHashCell
+instance : Inj SortAccountCellMap SortKItem where
+  inj := SortKItem.inj_SortAccountCellMap
   retr
-    | SortKItem.inj_SortPreviousHashCell x => some x
+    | SortKItem.inj_SortAccountCellMap x => some x
     | _ => none
 
-instance : Inj SortKCell SortKItem where
-  inj := SortKItem.inj_SortKCell
+instance : Inj SortIndexCell SortKItem where
+  inj := SortKItem.inj_SortIndexCell
   retr
-    | SortKItem.inj_SortKCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsOrderCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsOrderCell
-  retr
-    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
-    | _ => none
-
-instance : Inj SortCallGasCell SortKItem where
-  inj := SortKItem.inj_SortCallGasCell
-  retr
-    | SortKItem.inj_SortCallGasCell x => some x
-    | _ => none
-
-instance : Inj SortCodeCell SortKItem where
-  inj := SortKItem.inj_SortCodeCell
-  retr
-    | SortKItem.inj_SortCodeCell x => some x
-    | _ => none
-
-instance : Inj SortBytes SortKItem where
-  inj := SortKItem.inj_SortBytes
-  retr
-    | SortKItem.inj_SortBytes x => some x
-    | _ => none
-
-instance : Inj SortInterimStatesCell SortKItem where
-  inj := SortKItem.inj_SortInterimStatesCell
-  retr
-    | SortKItem.inj_SortInterimStatesCell x => some x
-    | _ => none
-
-instance : Inj SortAccountsCell SortKItem where
-  inj := SortKItem.inj_SortAccountsCell
-  retr
-    | SortKItem.inj_SortAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortOutputCell SortKItem where
-  inj := SortKItem.inj_SortOutputCell
-  retr
-    | SortKItem.inj_SortOutputCell x => some x
-    | _ => none
-
-instance : Inj SortCallStackCell SortKItem where
-  inj := SortKItem.inj_SortCallStackCell
-  retr
-    | SortKItem.inj_SortCallStackCell x => some x
-    | _ => none
-
-instance : Inj SortCallDataCell SortKItem where
-  inj := SortKItem.inj_SortCallDataCell
-  retr
-    | SortKItem.inj_SortCallDataCell x => some x
+    | SortKItem.inj_SortIndexCell x => some x
     | _ => none
 
 instance : Inj SortGasLimitCell SortKItem where
@@ -78,16 +24,132 @@ instance : Inj SortGasLimitCell SortKItem where
     | SortKItem.inj_SortGasLimitCell x => some x
     | _ => none
 
-instance : Inj SortTimestampCell SortKItem where
-  inj := SortKItem.inj_SortTimestampCell
+instance : Inj SortTxVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortTxVersionedHashesCell
   retr
-    | SortKItem.inj_SortTimestampCell x => some x
+    | SortKItem.inj_SortTxVersionedHashesCell x => some x
     | _ => none
 
-instance : Inj SortGasPriceCell SortKItem where
-  inj := SortKItem.inj_SortGasPriceCell
+instance : Inj SortWithdrawalsOrderCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsOrderCell
   retr
-    | SortKItem.inj_SortGasPriceCell x => some x
+    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
+    | _ => none
+
+instance : Inj SortBlockNonceCell SortKItem where
+  inj := SortKItem.inj_SortBlockNonceCell
+  retr
+    | SortKItem.inj_SortBlockNonceCell x => some x
+    | _ => none
+
+instance : Inj SortNumberCell SortKItem where
+  inj := SortKItem.inj_SortNumberCell
+  retr
+    | SortKItem.inj_SortNumberCell x => some x
+    | _ => none
+
+instance : Inj SortStateRootCell SortKItem where
+  inj := SortKItem.inj_SortStateRootCell
+  retr
+    | SortKItem.inj_SortStateRootCell x => some x
+    | _ => none
+
+instance : Inj SortScheduleCell SortKItem where
+  inj := SortKItem.inj_SortScheduleCell
+  retr
+    | SortKItem.inj_SortScheduleCell x => some x
+    | _ => none
+
+instance : Inj SortBinStackOp SortKItem where
+  inj := SortKItem.inj_SortBinStackOp
+  retr
+    | SortKItem.inj_SortBinStackOp x => some x
+    | _ => none
+
+instance : Inj SortBlockCell SortKItem where
+  inj := SortKItem.inj_SortBlockCell
+  retr
+    | SortKItem.inj_SortBlockCell x => some x
+    | _ => none
+
+instance : Inj SortStaticCell SortKItem where
+  inj := SortKItem.inj_SortStaticCell
+  retr
+    | SortKItem.inj_SortStaticCell x => some x
+    | _ => none
+
+instance : Inj SortMessageCell SortKItem where
+  inj := SortKItem.inj_SortMessageCell
+  retr
+    | SortKItem.inj_SortMessageCell x => some x
+    | _ => none
+
+instance : Inj SortBool SortKItem where
+  inj := SortKItem.inj_SortBool
+  retr
+    | SortKItem.inj_SortBool x => some x
+    | _ => none
+
+instance : Inj SortMessagesCell SortKItem where
+  inj := SortKItem.inj_SortMessagesCell
+  retr
+    | SortKItem.inj_SortMessagesCell x => some x
+    | _ => none
+
+instance : Inj SortTxMaxFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxFeeCell
+  retr
+    | SortKItem.inj_SortTxMaxFeeCell x => some x
+    | _ => none
+
+instance : Inj SortWordStack SortKItem where
+  inj := SortKItem.inj_SortWordStack
+  retr
+    | SortKItem.inj_SortWordStack x => some x
+    | _ => none
+
+instance : Inj SortToCell SortKItem where
+  inj := SortKItem.inj_SortToCell
+  retr
+    | SortKItem.inj_SortToCell x => some x
+    | _ => none
+
+instance : Inj SortIdCell SortKItem where
+  inj := SortKItem.inj_SortIdCell
+  retr
+    | SortKItem.inj_SortIdCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsCell
+  retr
+    | SortKItem.inj_SortWithdrawalsCell x => some x
+    | _ => none
+
+instance : Inj SortExtraDataCell SortKItem where
+  inj := SortKItem.inj_SortExtraDataCell
+  retr
+    | SortKItem.inj_SortExtraDataCell x => some x
+    | _ => none
+
+instance : Inj SortJSONKey SortKItem where
+  inj
+    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
+  retr
+    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
+    | SortKItem.inj_SortJSONKey x => some x
+    | _ => none
+
+instance : Inj SortTxAccessCell SortKItem where
+  inj := SortKItem.inj_SortTxAccessCell
+  retr
+    | SortKItem.inj_SortTxAccessCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalIDCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalIDCell
+  retr
+    | SortKItem.inj_SortWithdrawalIDCell x => some x
     | _ => none
 
 instance : Inj SortBaseFeeCell SortKItem where
@@ -96,34 +158,70 @@ instance : Inj SortBaseFeeCell SortKItem where
     | SortKItem.inj_SortBaseFeeCell x => some x
     | _ => none
 
+instance : Inj SortCodeCell SortKItem where
+  inj := SortKItem.inj_SortCodeCell
+  retr
+    | SortKItem.inj_SortCodeCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsRootCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsRootCell
+  retr
+    | SortKItem.inj_SortWithdrawalsRootCell x => some x
+    | _ => none
+
 instance : Inj SortCreatedAccountsCell SortKItem where
   inj := SortKItem.inj_SortCreatedAccountsCell
   retr
     | SortKItem.inj_SortCreatedAccountsCell x => some x
     | _ => none
 
-instance : Inj SortStatusCode SortKItem where
-  inj := SortKItem.inj_SortStatusCode
+instance : Inj SortScheduleConst SortKItem where
+  inj := SortKItem.inj_SortScheduleConst
   retr
-    | SortKItem.inj_SortStatusCode x => some x
+    | SortKItem.inj_SortScheduleConst x => some x
     | _ => none
 
-instance : Inj SortExcessBlobGasCell SortKItem where
-  inj := SortKItem.inj_SortExcessBlobGasCell
+instance : Inj SortWithdrawalsPendingCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsPendingCell
   retr
-    | SortKItem.inj_SortExcessBlobGasCell x => some x
+    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
     | _ => none
 
-instance : Inj SortBlobGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortBlobGasUsedCell
+instance : Inj SortKCell SortKItem where
+  inj := SortKItem.inj_SortKCell
   retr
-    | SortKItem.inj_SortBlobGasUsedCell x => some x
+    | SortKItem.inj_SortKCell x => some x
     | _ => none
 
-instance : Inj SortTxMaxBlobFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxBlobFeeCell
+instance : Inj SortPcCell SortKItem where
+  inj := SortKItem.inj_SortPcCell
   retr
-    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
+    | SortKItem.inj_SortPcCell x => some x
+    | _ => none
+
+instance : Inj SortAcctIDCell SortKItem where
+  inj := SortKItem.inj_SortAcctIDCell
+  retr
+    | SortKItem.inj_SortAcctIDCell x => some x
+    | _ => none
+
+instance : Inj SortGasPriceCell SortKItem where
+  inj := SortKItem.inj_SortGasPriceCell
+  retr
+    | SortKItem.inj_SortGasPriceCell x => some x
+    | _ => none
+
+instance : Inj SortMsgIDCell SortKItem where
+  inj := SortKItem.inj_SortMsgIDCell
+  retr
+    | SortKItem.inj_SortMsgIDCell x => some x
+    | _ => none
+
+instance : Inj SortSubstateCell SortKItem where
+  inj := SortKItem.inj_SortSubstateCell
+  retr
+    | SortKItem.inj_SortSubstateCell x => some x
     | _ => none
 
 instance : Inj SortMaybeOpCode SortKItem where
@@ -138,78 +236,34 @@ instance : Inj SortMaybeOpCode SortKItem where
     | SortKItem.inj_SortMaybeOpCode x => some x
     | _ => none
 
-instance : Inj SortWordStack SortKItem where
-  inj := SortKItem.inj_SortWordStack
+instance : Inj SortCallGasCell SortKItem where
+  inj := SortKItem.inj_SortCallGasCell
   retr
-    | SortKItem.inj_SortWordStack x => some x
+    | SortKItem.inj_SortCallGasCell x => some x
     | _ => none
 
-instance : Inj SortNumberCell SortKItem where
-  inj := SortKItem.inj_SortNumberCell
+instance : Inj SortReceiptsRootCell SortKItem where
+  inj := SortKItem.inj_SortReceiptsRootCell
   retr
-    | SortKItem.inj_SortNumberCell x => some x
+    | SortKItem.inj_SortReceiptsRootCell x => some x
     | _ => none
 
-instance : Inj SortJumpDestsCell SortKItem where
-  inj := SortKItem.inj_SortJumpDestsCell
+instance : Inj SortBlockhashesCell SortKItem where
+  inj := SortKItem.inj_SortBlockhashesCell
   retr
-    | SortKItem.inj_SortJumpDestsCell x => some x
+    | SortKItem.inj_SortBlockhashesCell x => some x
     | _ => none
 
-instance : Inj SortAccountCode SortKItem where
-  inj
-    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
+instance : Inj SortLogsBloomCell SortKItem where
+  inj := SortKItem.inj_SortLogsBloomCell
   retr
-    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
-    | SortKItem.inj_SortAccountCode x => some x
+    | SortKItem.inj_SortLogsBloomCell x => some x
     | _ => none
 
-instance : Inj SortWithdrawalsRootCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsRootCell
+instance : Inj SortAccountsCell SortKItem where
+  inj := SortKItem.inj_SortAccountsCell
   retr
-    | SortKItem.inj_SortWithdrawalsRootCell x => some x
-    | _ => none
-
-instance : Inj SortMsgIDCell SortKItem where
-  inj := SortKItem.inj_SortMsgIDCell
-  retr
-    | SortKItem.inj_SortMsgIDCell x => some x
-    | _ => none
-
-instance : Inj SortProgramCell SortKItem where
-  inj := SortKItem.inj_SortProgramCell
-  retr
-    | SortKItem.inj_SortProgramCell x => some x
-    | _ => none
-
-instance : Inj SortMessageCellMap SortKItem where
-  inj := SortKItem.inj_SortMessageCellMap
-  retr
-    | SortKItem.inj_SortMessageCellMap x => some x
-    | _ => none
-
-instance : Inj SortSelfDestructCell SortKItem where
-  inj := SortKItem.inj_SortSelfDestructCell
-  retr
-    | SortKItem.inj_SortSelfDestructCell x => some x
-    | _ => none
-
-instance : Inj SortCallStateCell SortKItem where
-  inj := SortKItem.inj_SortCallStateCell
-  retr
-    | SortKItem.inj_SortCallStateCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalCell
-  retr
-    | SortKItem.inj_SortWithdrawalCell x => some x
-    | _ => none
-
-instance : Inj SortRefundCell SortKItem where
-  inj := SortKItem.inj_SortRefundCell
-  retr
-    | SortKItem.inj_SortRefundCell x => some x
+    | SortKItem.inj_SortAccountsCell x => some x
     | _ => none
 
 instance : Inj SortAccount SortKItem where
@@ -221,138 +275,10 @@ instance : Inj SortAccount SortKItem where
     | SortKItem.inj_SortAccount x => some x
     | _ => none
 
-instance : Inj SortGeneratedCounterCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedCounterCell
-  retr
-    | SortKItem.inj_SortGeneratedCounterCell x => some x
-    | _ => none
-
-instance : Inj SortTxGasLimitCell SortKItem where
-  inj := SortKItem.inj_SortTxGasLimitCell
-  retr
-    | SortKItem.inj_SortTxGasLimitCell x => some x
-    | _ => none
-
-instance : Inj SortSigRCell SortKItem where
-  inj := SortKItem.inj_SortSigRCell
-  retr
-    | SortKItem.inj_SortSigRCell x => some x
-    | _ => none
-
-instance : Inj SortBlockCell SortKItem where
-  inj := SortKItem.inj_SortBlockCell
-  retr
-    | SortKItem.inj_SortBlockCell x => some x
-    | _ => none
-
-instance : Inj SortSigSCell SortKItem where
-  inj := SortKItem.inj_SortSigSCell
-  retr
-    | SortKItem.inj_SortSigSCell x => some x
-    | _ => none
-
-instance : Inj SortDifficultyCell SortKItem where
-  inj := SortKItem.inj_SortDifficultyCell
-  retr
-    | SortKItem.inj_SortDifficultyCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalIDCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalIDCell
-  retr
-    | SortKItem.inj_SortWithdrawalIDCell x => some x
-    | _ => none
-
-instance : Inj SortGas SortKItem where
-  inj
-    | SortGas.inj_SortInt x => SortKItem.inj_SortInt x
-  retr
-    | SortKItem.inj_SortInt x => some (SortGas.inj_SortInt x)
-    | SortKItem.inj_SortGas x => some x
-    | _ => none
-
-instance : Inj SortModeCell SortKItem where
-  inj := SortKItem.inj_SortModeCell
-  retr
-    | SortKItem.inj_SortModeCell x => some x
-    | _ => none
-
-instance : Inj SortCallValueCell SortKItem where
-  inj := SortKItem.inj_SortCallValueCell
-  retr
-    | SortKItem.inj_SortCallValueCell x => some x
-    | _ => none
-
-instance : Inj SortTransactionsRootCell SortKItem where
-  inj := SortKItem.inj_SortTransactionsRootCell
-  retr
-    | SortKItem.inj_SortTransactionsRootCell x => some x
-    | _ => none
-
-instance : Inj SortTxVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortTxVersionedHashesCell
-  retr
-    | SortKItem.inj_SortTxVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortAccessedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortAccessedAccountsCell
-  retr
-    | SortKItem.inj_SortAccessedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortKevmCell SortKItem where
-  inj := SortKItem.inj_SortKevmCell
-  retr
-    | SortKItem.inj_SortKevmCell x => some x
-    | _ => none
-
-instance : Inj SortOmmersHashCell SortKItem where
-  inj := SortKItem.inj_SortOmmersHashCell
-  retr
-    | SortKItem.inj_SortOmmersHashCell x => some x
-    | _ => none
-
-instance : Inj SortBeaconRootCell SortKItem where
-  inj := SortKItem.inj_SortBeaconRootCell
-  retr
-    | SortKItem.inj_SortBeaconRootCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsCell
-  retr
-    | SortKItem.inj_SortWithdrawalsCell x => some x
-    | _ => none
-
-instance : Inj SortMessagesCell SortKItem where
-  inj := SortKItem.inj_SortMessagesCell
-  retr
-    | SortKItem.inj_SortMessagesCell x => some x
-    | _ => none
-
-instance : Inj SortExtraDataCell SortKItem where
-  inj := SortKItem.inj_SortExtraDataCell
-  retr
-    | SortKItem.inj_SortExtraDataCell x => some x
-    | _ => none
-
-instance : Inj SortMixHashCell SortKItem where
-  inj := SortKItem.inj_SortMixHashCell
-  retr
-    | SortKItem.inj_SortMixHashCell x => some x
-    | _ => none
-
 instance : Inj SortAccessedStorageCell SortKItem where
   inj := SortKItem.inj_SortAccessedStorageCell
   retr
     | SortKItem.inj_SortAccessedStorageCell x => some x
-    | _ => none
-
-instance : Inj SortBlockNonceCell SortKItem where
-  inj := SortKItem.inj_SortBlockNonceCell
-  retr
-    | SortKItem.inj_SortBlockNonceCell x => some x
     | _ => none
 
 instance : Inj SortInternalOp SortKItem where
@@ -361,166 +287,28 @@ instance : Inj SortInternalOp SortKItem where
     | SortKItem.inj_SortInternalOp x => some x
     | _ => none
 
-instance : Inj SortValidatorIndexCell SortKItem where
-  inj := SortKItem.inj_SortValidatorIndexCell
+instance : Inj SortWithdrawalCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalCell
   retr
-    | SortKItem.inj_SortValidatorIndexCell x => some x
+    | SortKItem.inj_SortWithdrawalCell x => some x
     | _ => none
 
-instance : Inj SortGeneratedTopCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedTopCell
+instance : Inj SortKevmCell SortKItem where
+  inj := SortKItem.inj_SortKevmCell
   retr
-    | SortKItem.inj_SortGeneratedTopCell x => some x
+    | SortKItem.inj_SortKevmCell x => some x
     | _ => none
 
-instance : Inj SortAmountCell SortKItem where
-  inj := SortKItem.inj_SortAmountCell
+instance : Inj SortScheduleFlag SortKItem where
+  inj := SortKItem.inj_SortScheduleFlag
   retr
-    | SortKItem.inj_SortAmountCell x => some x
+    | SortKItem.inj_SortScheduleFlag x => some x
     | _ => none
 
-instance : Inj SortBool SortKItem where
-  inj := SortKItem.inj_SortBool
+instance : Inj SortUseGasCell SortKItem where
+  inj := SortKItem.inj_SortUseGasCell
   retr
-    | SortKItem.inj_SortBool x => some x
-    | _ => none
-
-instance : Inj SortTouchedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortTouchedAccountsCell
-  retr
-    | SortKItem.inj_SortTouchedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortList SortKItem where
-  inj := SortKItem.inj_SortList
-  retr
-    | SortKItem.inj_SortList x => some x
-    | _ => none
-
-instance : Inj SortAcctIDCell SortKItem where
-  inj := SortKItem.inj_SortAcctIDCell
-  retr
-    | SortKItem.inj_SortAcctIDCell x => some x
-    | _ => none
-
-instance : Inj SortEvmCell SortKItem where
-  inj := SortKItem.inj_SortEvmCell
-  retr
-    | SortKItem.inj_SortEvmCell x => some x
-    | _ => none
-
-instance : Inj SortTransientStorageCell SortKItem where
-  inj := SortKItem.inj_SortTransientStorageCell
-  retr
-    | SortKItem.inj_SortTransientStorageCell x => some x
-    | _ => none
-
-instance : Inj SortPushOp SortKItem where
-  inj := SortKItem.inj_SortPushOp
-  retr
-    | SortKItem.inj_SortPushOp x => some x
-    | _ => none
-
-instance : Inj SortMessageCell SortKItem where
-  inj := SortKItem.inj_SortMessageCell
-  retr
-    | SortKItem.inj_SortMessageCell x => some x
-    | _ => none
-
-instance : Inj SortNonceCell SortKItem where
-  inj := SortKItem.inj_SortNonceCell
-  retr
-    | SortKItem.inj_SortNonceCell x => some x
-    | _ => none
-
-instance : Inj SortExitCodeCell SortKItem where
-  inj := SortKItem.inj_SortExitCodeCell
-  retr
-    | SortKItem.inj_SortExitCodeCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCell SortKItem where
-  inj := SortKItem.inj_SortAccountCell
-  retr
-    | SortKItem.inj_SortAccountCell x => some x
-    | _ => none
-
-instance : Inj SortSet SortKItem where
-  inj := SortKItem.inj_SortSet
-  retr
-    | SortKItem.inj_SortSet x => some x
-    | _ => none
-
-instance : Inj SortOrigStorageCell SortKItem where
-  inj := SortKItem.inj_SortOrigStorageCell
-  retr
-    | SortKItem.inj_SortOrigStorageCell x => some x
-    | _ => none
-
-instance : Inj SortValueCell SortKItem where
-  inj := SortKItem.inj_SortValueCell
-  retr
-    | SortKItem.inj_SortValueCell x => some x
-    | _ => none
-
-instance : Inj SortSigVCell SortKItem where
-  inj := SortKItem.inj_SortSigVCell
-  retr
-    | SortKItem.inj_SortSigVCell x => some x
-    | _ => none
-
-instance : Inj SortCallDepthCell SortKItem where
-  inj := SortKItem.inj_SortCallDepthCell
-  retr
-    | SortKItem.inj_SortCallDepthCell x => some x
-    | _ => none
-
-instance : Inj SortTxPriorityFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxPriorityFeeCell
-  retr
-    | SortKItem.inj_SortTxPriorityFeeCell x => some x
-    | _ => none
-
-instance : Inj SortGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortGasUsedCell
-  retr
-    | SortKItem.inj_SortGasUsedCell x => some x
-    | _ => none
-
-instance : Inj SortWordStackCell SortKItem where
-  inj := SortKItem.inj_SortWordStackCell
-  retr
-    | SortKItem.inj_SortWordStackCell x => some x
-    | _ => none
-
-instance : Inj SortIdCell SortKItem where
-  inj := SortKItem.inj_SortIdCell
-  retr
-    | SortKItem.inj_SortIdCell x => some x
-    | _ => none
-
-instance : Inj SortJSONs SortKItem where
-  inj := SortKItem.inj_SortJSONs
-  retr
-    | SortKItem.inj_SortJSONs x => some x
-    | _ => none
-
-instance : Inj SortCoinbaseCell SortKItem where
-  inj := SortKItem.inj_SortCoinbaseCell
-  retr
-    | SortKItem.inj_SortCoinbaseCell x => some x
-    | _ => none
-
-instance : Inj SortStorageCell SortKItem where
-  inj := SortKItem.inj_SortStorageCell
-  retr
-    | SortKItem.inj_SortStorageCell x => some x
-    | _ => none
-
-instance : Inj SortSchedule SortKItem where
-  inj := SortKItem.inj_SortSchedule
-  retr
-    | SortKItem.inj_SortSchedule x => some x
+    | SortKItem.inj_SortUseGasCell x => some x
     | _ => none
 
 instance : Inj SortTxGasPriceCell SortKItem where
@@ -529,10 +317,274 @@ instance : Inj SortTxGasPriceCell SortKItem where
     | SortKItem.inj_SortTxGasPriceCell x => some x
     | _ => none
 
+instance : Inj SortTransientStorageCell SortKItem where
+  inj := SortKItem.inj_SortTransientStorageCell
+  retr
+    | SortKItem.inj_SortTransientStorageCell x => some x
+    | _ => none
+
+instance : Inj SortNetworkCell SortKItem where
+  inj := SortKItem.inj_SortNetworkCell
+  retr
+    | SortKItem.inj_SortNetworkCell x => some x
+    | _ => none
+
+instance : Inj SortProgramCell SortKItem where
+  inj := SortKItem.inj_SortProgramCell
+  retr
+    | SortKItem.inj_SortProgramCell x => some x
+    | _ => none
+
+instance : Inj SortLogCell SortKItem where
+  inj := SortKItem.inj_SortLogCell
+  retr
+    | SortKItem.inj_SortLogCell x => some x
+    | _ => none
+
+instance : Inj SortMode SortKItem where
+  inj := SortKItem.inj_SortMode
+  retr
+    | SortKItem.inj_SortMode x => some x
+    | _ => none
+
+instance : Inj SortVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortVersionedHashesCell
+  retr
+    | SortKItem.inj_SortVersionedHashesCell x => some x
+    | _ => none
+
+instance : Inj SortTransactionsRootCell SortKItem where
+  inj := SortKItem.inj_SortTransactionsRootCell
+  retr
+    | SortKItem.inj_SortTransactionsRootCell x => some x
+    | _ => none
+
+instance : Inj SortStorageCell SortKItem where
+  inj := SortKItem.inj_SortStorageCell
+  retr
+    | SortKItem.inj_SortStorageCell x => some x
+    | _ => none
+
+instance : Inj SortTimestampCell SortKItem where
+  inj := SortKItem.inj_SortTimestampCell
+  retr
+    | SortKItem.inj_SortTimestampCell x => some x
+    | _ => none
+
+instance : Inj SortEvmCell SortKItem where
+  inj := SortKItem.inj_SortEvmCell
+  retr
+    | SortKItem.inj_SortEvmCell x => some x
+    | _ => none
+
+instance : Inj SortTxPendingCell SortKItem where
+  inj := SortKItem.inj_SortTxPendingCell
+  retr
+    | SortKItem.inj_SortTxPendingCell x => some x
+    | _ => none
+
+instance : Inj SortBeaconRootCell SortKItem where
+  inj := SortKItem.inj_SortBeaconRootCell
+  retr
+    | SortKItem.inj_SortBeaconRootCell x => some x
+    | _ => none
+
+instance : Inj SortMixHashCell SortKItem where
+  inj := SortKItem.inj_SortMixHashCell
+  retr
+    | SortKItem.inj_SortMixHashCell x => some x
+    | _ => none
+
+instance : Inj SortDifficultyCell SortKItem where
+  inj := SortKItem.inj_SortDifficultyCell
+  retr
+    | SortKItem.inj_SortDifficultyCell x => some x
+    | _ => none
+
+instance : Inj SortGasCell SortKItem where
+  inj := SortKItem.inj_SortGasCell
+  retr
+    | SortKItem.inj_SortGasCell x => some x
+    | _ => none
+
+instance : Inj SortMemoryUsedCell SortKItem where
+  inj := SortKItem.inj_SortMemoryUsedCell
+  retr
+    | SortKItem.inj_SortMemoryUsedCell x => some x
+    | _ => none
+
+instance : Inj SortTxNonceCell SortKItem where
+  inj := SortKItem.inj_SortTxNonceCell
+  retr
+    | SortKItem.inj_SortTxNonceCell x => some x
+    | _ => none
+
+instance : Inj SortWordStackCell SortKItem where
+  inj := SortKItem.inj_SortWordStackCell
+  retr
+    | SortKItem.inj_SortWordStackCell x => some x
+    | _ => none
+
+instance : Inj SortOrigStorageCell SortKItem where
+  inj := SortKItem.inj_SortOrigStorageCell
+  retr
+    | SortKItem.inj_SortOrigStorageCell x => some x
+    | _ => none
+
+instance : Inj SortTxChainIDCell SortKItem where
+  inj := SortKItem.inj_SortTxChainIDCell
+  retr
+    | SortKItem.inj_SortTxChainIDCell x => some x
+    | _ => none
+
+instance : Inj SortStatusCodeCell SortKItem where
+  inj := SortKItem.inj_SortStatusCodeCell
+  retr
+    | SortKItem.inj_SortStatusCodeCell x => some x
+    | _ => none
+
+instance : Inj SortTxOrderCell SortKItem where
+  inj := SortKItem.inj_SortTxOrderCell
+  retr
+    | SortKItem.inj_SortTxOrderCell x => some x
+    | _ => none
+
+instance : Inj SortCallStateCell SortKItem where
+  inj := SortKItem.inj_SortCallStateCell
+  retr
+    | SortKItem.inj_SortCallStateCell x => some x
+    | _ => none
+
+instance : Inj SortEthereumCell SortKItem where
+  inj := SortKItem.inj_SortEthereumCell
+  retr
+    | SortKItem.inj_SortEthereumCell x => some x
+    | _ => none
+
+instance : Inj SortNonceCell SortKItem where
+  inj := SortKItem.inj_SortNonceCell
+  retr
+    | SortKItem.inj_SortNonceCell x => some x
+    | _ => none
+
+instance : Inj SortRefundCell SortKItem where
+  inj := SortKItem.inj_SortRefundCell
+  retr
+    | SortKItem.inj_SortRefundCell x => some x
+    | _ => none
+
+instance : Inj SortAccessedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortAccessedAccountsCell
+  retr
+    | SortKItem.inj_SortAccessedAccountsCell x => some x
+    | _ => none
+
 instance : Inj SortMap SortKItem where
   inj := SortKItem.inj_SortMap
   retr
     | SortKItem.inj_SortMap x => some x
+    | _ => none
+
+instance : Inj SortDataCell SortKItem where
+  inj := SortKItem.inj_SortDataCell
+  retr
+    | SortKItem.inj_SortDataCell x => some x
+    | _ => none
+
+instance : Inj SortOriginCell SortKItem where
+  inj := SortKItem.inj_SortOriginCell
+  retr
+    | SortKItem.inj_SortOriginCell x => some x
+    | _ => none
+
+instance : Inj SortSigRCell SortKItem where
+  inj := SortKItem.inj_SortSigRCell
+  retr
+    | SortKItem.inj_SortSigRCell x => some x
+    | _ => none
+
+instance : Inj SortSigSCell SortKItem where
+  inj := SortKItem.inj_SortSigSCell
+  retr
+    | SortKItem.inj_SortSigSCell x => some x
+    | _ => none
+
+instance : Inj SortInterimStatesCell SortKItem where
+  inj := SortKItem.inj_SortInterimStatesCell
+  retr
+    | SortKItem.inj_SortInterimStatesCell x => some x
+    | _ => none
+
+instance : Inj SortStatusCode SortKItem where
+  inj := SortKItem.inj_SortStatusCode
+  retr
+    | SortKItem.inj_SortStatusCode x => some x
+    | _ => none
+
+instance : Inj SortCallStackCell SortKItem where
+  inj := SortKItem.inj_SortCallStackCell
+  retr
+    | SortKItem.inj_SortCallStackCell x => some x
+    | _ => none
+
+instance : Inj SortSchedule SortKItem where
+  inj := SortKItem.inj_SortSchedule
+  retr
+    | SortKItem.inj_SortSchedule x => some x
+    | _ => none
+
+instance : Inj SortPushOp SortKItem where
+  inj := SortKItem.inj_SortPushOp
+  retr
+    | SortKItem.inj_SortPushOp x => some x
+    | _ => none
+
+instance : Inj SortTouchedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortTouchedAccountsCell
+  retr
+    | SortKItem.inj_SortTouchedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortOmmersHashCell SortKItem where
+  inj := SortKItem.inj_SortOmmersHashCell
+  retr
+    | SortKItem.inj_SortOmmersHashCell x => some x
+    | _ => none
+
+instance : Inj SortJSONs SortKItem where
+  inj := SortKItem.inj_SortJSONs
+  retr
+    | SortKItem.inj_SortJSONs x => some x
+    | _ => none
+
+instance : Inj SortSet SortKItem where
+  inj := SortKItem.inj_SortSet
+  retr
+    | SortKItem.inj_SortSet x => some x
+    | _ => none
+
+instance : Inj SortValueCell SortKItem where
+  inj := SortKItem.inj_SortValueCell
+  retr
+    | SortKItem.inj_SortValueCell x => some x
+    | _ => none
+
+instance : Inj SortModeCell SortKItem where
+  inj := SortKItem.inj_SortModeCell
+  retr
+    | SortKItem.inj_SortModeCell x => some x
+    | _ => none
+
+instance : Inj SortTxType SortKItem where
+  inj := SortKItem.inj_SortTxType
+  retr
+    | SortKItem.inj_SortTxType x => some x
+    | _ => none
+
+instance : Inj SortChainIDCell SortKItem where
+  inj := SortKItem.inj_SortChainIDCell
+  retr
+    | SortKItem.inj_SortChainIDCell x => some x
     | _ => none
 
 instance : Inj SortInt SortKItem where
@@ -541,16 +593,42 @@ instance : Inj SortInt SortKItem where
     | SortKItem.inj_SortInt x => some x
     | _ => none
 
-instance : Inj SortSubstateCell SortKItem where
-  inj := SortKItem.inj_SortSubstateCell
+instance : Inj SortPreviousHashCell SortKItem where
+  inj := SortKItem.inj_SortPreviousHashCell
   retr
-    | SortKItem.inj_SortSubstateCell x => some x
+    | SortKItem.inj_SortPreviousHashCell x => some x
     | _ => none
 
-instance : Inj SortScheduleConst SortKItem where
-  inj := SortKItem.inj_SortScheduleConst
+instance : Inj SortAccountCell SortKItem where
+  inj := SortKItem.inj_SortAccountCell
   retr
-    | SortKItem.inj_SortScheduleConst x => some x
+    | SortKItem.inj_SortAccountCell x => some x
+    | _ => none
+
+instance : Inj SortMessageCellMap SortKItem where
+  inj := SortKItem.inj_SortMessageCellMap
+  retr
+    | SortKItem.inj_SortMessageCellMap x => some x
+    | _ => none
+
+instance : Inj SortTxMaxBlobFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxBlobFeeCell
+  retr
+    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCode SortKItem where
+  inj
+    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
+  retr
+    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
+    | SortKItem.inj_SortAccountCode x => some x
+    | _ => none
+
+instance : Inj SortExitCodeCell SortKItem where
+  inj := SortKItem.inj_SortExitCodeCell
+  retr
+    | SortKItem.inj_SortExitCodeCell x => some x
     | _ => none
 
 instance : Inj SortJSON SortKItem where
@@ -572,88 +650,22 @@ instance : Inj SortJSON SortKItem where
     | SortKItem.inj_SortJSON x => some x
     | _ => none
 
-instance : Inj SortTxChainIDCell SortKItem where
-  inj := SortKItem.inj_SortTxChainIDCell
+instance : Inj SortBlobGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortBlobGasUsedCell
   retr
-    | SortKItem.inj_SortTxChainIDCell x => some x
+    | SortKItem.inj_SortBlobGasUsedCell x => some x
     | _ => none
 
-instance : Inj SortStaticCell SortKItem where
-  inj := SortKItem.inj_SortStaticCell
+instance : Inj SortTxGasLimitCell SortKItem where
+  inj := SortKItem.inj_SortTxGasLimitCell
   retr
-    | SortKItem.inj_SortStaticCell x => some x
+    | SortKItem.inj_SortTxGasLimitCell x => some x
     | _ => none
 
-instance : Inj SortAddressCell SortKItem where
-  inj := SortKItem.inj_SortAddressCell
+instance : Inj SortCallDataCell SortKItem where
+  inj := SortKItem.inj_SortCallDataCell
   retr
-    | SortKItem.inj_SortAddressCell x => some x
-    | _ => none
-
-instance : Inj SortCallerCell SortKItem where
-  inj := SortKItem.inj_SortCallerCell
-  retr
-    | SortKItem.inj_SortCallerCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleCell SortKItem where
-  inj := SortKItem.inj_SortScheduleCell
-  retr
-    | SortKItem.inj_SortScheduleCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalCellMap SortKItem where
-  inj := SortKItem.inj_SortWithdrawalCellMap
-  retr
-    | SortKItem.inj_SortWithdrawalCellMap x => some x
-    | _ => none
-
-instance : Inj SortBalanceCell SortKItem where
-  inj := SortKItem.inj_SortBalanceCell
-  retr
-    | SortKItem.inj_SortBalanceCell x => some x
-    | _ => none
-
-instance : Inj SortLocalMemCell SortKItem where
-  inj := SortKItem.inj_SortLocalMemCell
-  retr
-    | SortKItem.inj_SortLocalMemCell x => some x
-    | _ => none
-
-instance : Inj SortTxMaxFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxFeeCell
-  retr
-    | SortKItem.inj_SortTxMaxFeeCell x => some x
-    | _ => none
-
-instance : Inj SortGasCell SortKItem where
-  inj := SortKItem.inj_SortGasCell
-  retr
-    | SortKItem.inj_SortGasCell x => some x
-    | _ => none
-
-instance : Inj SortReceiptsRootCell SortKItem where
-  inj := SortKItem.inj_SortReceiptsRootCell
-  retr
-    | SortKItem.inj_SortReceiptsRootCell x => some x
-    | _ => none
-
-instance : Inj SortTxNonceCell SortKItem where
-  inj := SortKItem.inj_SortTxNonceCell
-  retr
-    | SortKItem.inj_SortTxNonceCell x => some x
-    | _ => none
-
-instance : Inj SortTxOrderCell SortKItem where
-  inj := SortKItem.inj_SortTxOrderCell
-  retr
-    | SortKItem.inj_SortTxOrderCell x => some x
-    | _ => none
-
-instance : Inj SortToCell SortKItem where
-  inj := SortKItem.inj_SortToCell
-  retr
-    | SortKItem.inj_SortToCell x => some x
+    | SortKItem.inj_SortCallDataCell x => some x
     | _ => none
 
 instance : Inj SortOmmerBlockHeadersCell SortKItem where
@@ -662,10 +674,70 @@ instance : Inj SortOmmerBlockHeadersCell SortKItem where
     | SortKItem.inj_SortOmmerBlockHeadersCell x => some x
     | _ => none
 
-instance : Inj SortDataCell SortKItem where
-  inj := SortKItem.inj_SortDataCell
+instance : Inj SortOutputCell SortKItem where
+  inj := SortKItem.inj_SortOutputCell
   retr
-    | SortKItem.inj_SortDataCell x => some x
+    | SortKItem.inj_SortOutputCell x => some x
+    | _ => none
+
+instance : Inj SortCallValueCell SortKItem where
+  inj := SortKItem.inj_SortCallValueCell
+  retr
+    | SortKItem.inj_SortCallValueCell x => some x
+    | _ => none
+
+instance : Inj SortList SortKItem where
+  inj := SortKItem.inj_SortList
+  retr
+    | SortKItem.inj_SortList x => some x
+    | _ => none
+
+instance : Inj SortValidatorIndexCell SortKItem where
+  inj := SortKItem.inj_SortValidatorIndexCell
+  retr
+    | SortKItem.inj_SortValidatorIndexCell x => some x
+    | _ => none
+
+instance : Inj SortSelfDestructCell SortKItem where
+  inj := SortKItem.inj_SortSelfDestructCell
+  retr
+    | SortKItem.inj_SortSelfDestructCell x => some x
+    | _ => none
+
+instance : Inj SortJumpDestsCell SortKItem where
+  inj := SortKItem.inj_SortJumpDestsCell
+  retr
+    | SortKItem.inj_SortJumpDestsCell x => some x
+    | _ => none
+
+instance : Inj SortBalanceCell SortKItem where
+  inj := SortKItem.inj_SortBalanceCell
+  retr
+    | SortKItem.inj_SortBalanceCell x => some x
+    | _ => none
+
+instance : Inj SortCallDepthCell SortKItem where
+  inj := SortKItem.inj_SortCallDepthCell
+  retr
+    | SortKItem.inj_SortCallDepthCell x => some x
+    | _ => none
+
+instance : Inj SortAddressCell SortKItem where
+  inj := SortKItem.inj_SortAddressCell
+  retr
+    | SortKItem.inj_SortAddressCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalCellMap SortKItem where
+  inj := SortKItem.inj_SortWithdrawalCellMap
+  retr
+    | SortKItem.inj_SortWithdrawalCellMap x => some x
+    | _ => none
+
+instance : Inj SortCoinbaseCell SortKItem where
+  inj := SortKItem.inj_SortCoinbaseCell
+  retr
+    | SortKItem.inj_SortCoinbaseCell x => some x
     | _ => none
 
 instance : Inj SortTxTypeCell SortKItem where
@@ -674,132 +746,66 @@ instance : Inj SortTxTypeCell SortKItem where
     | SortKItem.inj_SortTxTypeCell x => some x
     | _ => none
 
-instance : Inj SortIndexCell SortKItem where
-  inj := SortKItem.inj_SortIndexCell
-  retr
-    | SortKItem.inj_SortIndexCell x => some x
-    | _ => none
-
-instance : Inj SortStatusCodeCell SortKItem where
-  inj := SortKItem.inj_SortStatusCodeCell
-  retr
-    | SortKItem.inj_SortStatusCodeCell x => some x
-    | _ => none
-
-instance : Inj SortTxPendingCell SortKItem where
-  inj := SortKItem.inj_SortTxPendingCell
-  retr
-    | SortKItem.inj_SortTxPendingCell x => some x
-    | _ => none
-
-instance : Inj SortEthereumCell SortKItem where
-  inj := SortKItem.inj_SortEthereumCell
-  retr
-    | SortKItem.inj_SortEthereumCell x => some x
-    | _ => none
-
-instance : Inj SortVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortVersionedHashesCell
-  retr
-    | SortKItem.inj_SortVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortJSONKey SortKItem where
+instance : Inj SortGas SortKItem where
   inj
-    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
+    | SortGas.inj_SortInt x => SortKItem.inj_SortInt x
   retr
-    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
-    | SortKItem.inj_SortJSONKey x => some x
+    | SortKItem.inj_SortInt x => some (SortGas.inj_SortInt x)
+    | SortKItem.inj_SortGas x => some x
     | _ => none
 
-instance : Inj SortTxType SortKItem where
-  inj := SortKItem.inj_SortTxType
+instance : Inj SortSigVCell SortKItem where
+  inj := SortKItem.inj_SortSigVCell
   retr
-    | SortKItem.inj_SortTxType x => some x
+    | SortKItem.inj_SortSigVCell x => some x
     | _ => none
 
-instance : Inj SortNetworkCell SortKItem where
-  inj := SortKItem.inj_SortNetworkCell
+instance : Inj SortBytes SortKItem where
+  inj := SortKItem.inj_SortBytes
   retr
-    | SortKItem.inj_SortNetworkCell x => some x
+    | SortKItem.inj_SortBytes x => some x
     | _ => none
 
-instance : Inj SortWithdrawalsPendingCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsPendingCell
+instance : Inj SortGeneratedTopCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedTopCell
   retr
-    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
+    | SortKItem.inj_SortGeneratedTopCell x => some x
     | _ => none
 
-instance : Inj SortAccountCellMap SortKItem where
-  inj := SortKItem.inj_SortAccountCellMap
+instance : Inj SortExcessBlobGasCell SortKItem where
+  inj := SortKItem.inj_SortExcessBlobGasCell
   retr
-    | SortKItem.inj_SortAccountCellMap x => some x
+    | SortKItem.inj_SortExcessBlobGasCell x => some x
     | _ => none
 
-instance : Inj SortStateRootCell SortKItem where
-  inj := SortKItem.inj_SortStateRootCell
+instance : Inj SortTxPriorityFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxPriorityFeeCell
   retr
-    | SortKItem.inj_SortStateRootCell x => some x
+    | SortKItem.inj_SortTxPriorityFeeCell x => some x
     | _ => none
 
-instance : Inj SortPcCell SortKItem where
-  inj := SortKItem.inj_SortPcCell
+instance : Inj SortAmountCell SortKItem where
+  inj := SortKItem.inj_SortAmountCell
   retr
-    | SortKItem.inj_SortPcCell x => some x
+    | SortKItem.inj_SortAmountCell x => some x
     | _ => none
 
-instance : Inj SortUseGasCell SortKItem where
-  inj := SortKItem.inj_SortUseGasCell
+instance : Inj SortGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortGasUsedCell
   retr
-    | SortKItem.inj_SortUseGasCell x => some x
+    | SortKItem.inj_SortGasUsedCell x => some x
     | _ => none
 
-instance : Inj SortMode SortKItem where
-  inj := SortKItem.inj_SortMode
+instance : Inj SortCallerCell SortKItem where
+  inj := SortKItem.inj_SortCallerCell
   retr
-    | SortKItem.inj_SortMode x => some x
+    | SortKItem.inj_SortCallerCell x => some x
     | _ => none
 
-instance : Inj SortMemoryUsedCell SortKItem where
-  inj := SortKItem.inj_SortMemoryUsedCell
+instance : Inj SortLocalMemCell SortKItem where
+  inj := SortKItem.inj_SortLocalMemCell
   retr
-    | SortKItem.inj_SortMemoryUsedCell x => some x
-    | _ => none
-
-instance : Inj SortLogsBloomCell SortKItem where
-  inj := SortKItem.inj_SortLogsBloomCell
-  retr
-    | SortKItem.inj_SortLogsBloomCell x => some x
-    | _ => none
-
-instance : Inj SortLogCell SortKItem where
-  inj := SortKItem.inj_SortLogCell
-  retr
-    | SortKItem.inj_SortLogCell x => some x
-    | _ => none
-
-instance : Inj SortBinStackOp SortKItem where
-  inj := SortKItem.inj_SortBinStackOp
-  retr
-    | SortKItem.inj_SortBinStackOp x => some x
-    | _ => none
-
-instance : Inj SortOriginCell SortKItem where
-  inj := SortKItem.inj_SortOriginCell
-  retr
-    | SortKItem.inj_SortOriginCell x => some x
-    | _ => none
-
-instance : Inj SortBlockhashesCell SortKItem where
-  inj := SortKItem.inj_SortBlockhashesCell
-  retr
-    | SortKItem.inj_SortBlockhashesCell x => some x
-    | _ => none
-
-instance : Inj SortTxAccessCell SortKItem where
-  inj := SortKItem.inj_SortTxAccessCell
-  retr
-    | SortKItem.inj_SortTxAccessCell x => some x
+    | SortKItem.inj_SortLocalMemCell x => some x
     | _ => none
 
 instance : Inj SortInt SortGas where
@@ -807,22 +813,28 @@ instance : Inj SortInt SortGas where
   retr
     | SortGas.inj_SortInt x => some x
 
+instance : Inj SortMap SortJSON where
+  inj := SortJSON.inj_SortMap
+  retr
+    | SortJSON.inj_SortMap x => some x
+    | _ => none
+
 instance : Inj SortBool SortJSON where
   inj := SortJSON.inj_SortBool
   retr
     | SortJSON.inj_SortBool x => some x
     | _ => none
 
+instance : Inj SortBytes SortJSON where
+  inj := SortJSON.inj_SortBytes
+  retr
+    | SortJSON.inj_SortBytes x => some x
+    | _ => none
+
 instance : Inj SortTxType SortJSON where
   inj := SortJSON.inj_SortTxType
   retr
     | SortJSON.inj_SortTxType x => some x
-    | _ => none
-
-instance : Inj SortMap SortJSON where
-  inj := SortJSON.inj_SortMap
-  retr
-    | SortJSON.inj_SortMap x => some x
     | _ => none
 
 instance : Inj SortInt SortJSON where
@@ -840,12 +852,6 @@ instance : Inj SortAccount SortJSON where
     | SortJSON.inj_SortAccount x => some x
     | _ => none
 
-instance : Inj SortBytes SortJSON where
-  inj := SortJSON.inj_SortBytes
-  retr
-    | SortJSON.inj_SortBytes x => some x
-    | _ => none
-
 instance : Inj SortInt SortJSONKey where
   inj := SortJSONKey.inj_SortInt
   retr
@@ -857,16 +863,16 @@ instance : Inj SortPushOp SortMaybeOpCode where
     | SortMaybeOpCode.inj_SortPushOp x => some x
     | _ => none
 
-instance : Inj SortBinStackOp SortMaybeOpCode where
-  inj := SortMaybeOpCode.inj_SortBinStackOp
-  retr
-    | SortMaybeOpCode.inj_SortBinStackOp x => some x
-    | _ => none
-
 instance : Inj SortInternalOp SortMaybeOpCode where
   inj := SortMaybeOpCode.inj_SortInternalOp
   retr
     | SortMaybeOpCode.inj_SortInternalOp x => some x
+    | _ => none
+
+instance : Inj SortBinStackOp SortMaybeOpCode where
+  inj := SortMaybeOpCode.inj_SortBinStackOp
+  retr
+    | SortMaybeOpCode.inj_SortBinStackOp x => some x
     | _ => none
 
 instance : Inj SortInt SortAccount where

--- a/EvmEquivalence/KEVM2Lean/Rewrite.lean
+++ b/EvmEquivalence/KEVM2Lean/Rewrite.lean
@@ -6,7 +6,7 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
     (t1 : Rewrites s1 s2)
     (t2 : Rewrites s2 s3)
     : Rewrites s1 s3
-  | SUMMARY_ADD_2_SPEC_BASIC_BLOCK_21_TO_20
+  | ADD_SUMMARY_ADD_SUMMARY_0
     {GAS_CELL PC_CELL W0 W1 _Val0 _Val3 _Val4 _Val5 _Val6 _Val7 : SortInt}
     {K_CELL : SortK}
     {SCHEDULE_CELL : SortSchedule}
@@ -120,7 +120,7 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
             block := _Gen21 },
           network := _DotVar2 } },
       generatedCounter := _DotVar0 }
-  | SUMMARY_PUSHZERO_0_SPEC_BASIC_BLOCK_25_TO_24
+  | PUSHZERO_SUMMARY_PUSHZERO_SUMMARY_1
     {GAS_CELL PC_CELL _Val0 _Val11 _Val12 _Val13 _Val3 _Val6 : SortInt}
     {K_CELL : SortK}
     {SCHEDULE_CELL : SortSchedule}
@@ -152,17 +152,17 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
     {_Gen7 : SortMemoryUsedCell}
     {_Gen8 : SortCallGasCell}
     {_Gen9 : SortStaticCell}
-    (defn_Val0 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gbase_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val0)
-    (defn_Val1 : «_<=Int_» _Val0 GAS_CELL = some _Val1)
-    (defn_Val2 : _andBool_ USEGAS_CELL _Val1 = some _Val2)
+    (defn_Val0 : sizeWordStackAux WS 0 = some _Val0)
+    (defn_Val1 : «_<Int_» _Val0 0 = some _Val1)
+    (defn_Val2 : notBool_ _Val1 = some _Val2)
     (defn_Val3 : sizeWordStackAux WS 0 = some _Val3)
-    (defn_Val4 : «_<Int_» _Val3 0 = some _Val4)
+    (defn_Val4 : «_<Int_» 1023 _Val3 = some _Val4)
     (defn_Val5 : notBool_ _Val4 = some _Val5)
-    (defn_Val6 : sizeWordStackAux WS 0 = some _Val6)
-    (defn_Val7 : «_<Int_» 1023 _Val6 = some _Val7)
-    (defn_Val8 : notBool_ _Val7 = some _Val8)
-    (defn_Val9 : _andBool_ _Val5 _Val8 = some _Val9)
-    (defn_Val10 : _andBool_ _Val2 _Val9 = some _Val10)
+    (defn_Val6 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gbase_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val6)
+    (defn_Val7 : «_<=Int_» _Val6 GAS_CELL = some _Val7)
+    (defn_Val8 : _andBool_ _Val5 _Val7 = some _Val8)
+    (defn_Val9 : _andBool_ _Val2 _Val8 = some _Val9)
+    (defn_Val10 : _andBool_ USEGAS_CELL _Val9 = some _Val10)
     (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
     (defn_Val12 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gbase_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val12)
     (defn_Val13 : «_-Int_» GAS_CELL _Val12 = some _Val13)
@@ -239,4 +239,210 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
             blockhashes := _Gen20,
             block := _Gen21 },
           network := _DotVar2 } },
+      generatedCounter := _DotVar0 }
+  | SSTORE_SUMMARY_SSTORE_SUMMARY_1
+    {ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 : SortMap}
+    {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}
+    {K_CELL : SortK}
+    {SCHEDULE_CELL : SortSchedule}
+    {USEGAS_CELL _Val0 _Val12 _Val14 _Val15 _Val16 _Val17 _Val18 _Val26 _Val4 _Val5 : SortBool}
+    {WS : SortWordStack}
+    {_DotVar0 : SortGeneratedCounterCell}
+    {_DotVar6 _Val19 _Val20 _Val41 _Val42 : SortAccountCellMap}
+    {_Gen0 : SortProgramCell}
+    {_Gen1 : SortJumpDestsCell}
+    {_Gen10 : SortLogCell}
+    {_Gen11 : SortAccessedAccountsCell}
+    {_Gen12 : SortCreatedAccountsCell}
+    {_Gen13 : SortOutputCell}
+    {_Gen14 : SortStatusCodeCell}
+    {_Gen15 : SortCallStackCell}
+    {_Gen16 : SortInterimStatesCell}
+    {_Gen17 : SortTouchedAccountsCell}
+    {_Gen18 : SortVersionedHashesCell}
+    {_Gen19 : SortGasPriceCell}
+    {_Gen2 : SortCallerCell}
+    {_Gen20 : SortOriginCell}
+    {_Gen21 : SortBlockhashesCell}
+    {_Gen22 : SortBlockCell}
+    {_Gen23 : SortBalanceCell}
+    {_Gen24 : SortCodeCell}
+    {_Gen25 : SortTransientStorageCell}
+    {_Gen26 : SortNonceCell}
+    {_Gen27 : SortChainIDCell}
+    {_Gen28 : SortTxOrderCell}
+    {_Gen29 : SortTxPendingCell}
+    {_Gen3 : SortCallDataCell}
+    {_Gen30 : SortMessagesCell}
+    {_Gen31 : SortWithdrawalsPendingCell}
+    {_Gen32 : SortWithdrawalsOrderCell}
+    {_Gen33 : SortWithdrawalsCell}
+    {_Gen34 : SortExitCodeCell}
+    {_Gen35 : SortModeCell}
+    {_Gen4 : SortCallValueCell}
+    {_Gen5 : SortLocalMemCell}
+    {_Gen6 : SortMemoryUsedCell}
+    {_Gen7 : SortCallGasCell}
+    {_Gen8 : SortCallDepthCell}
+    {_Gen9 : SortSelfDestructCell}
+    {_Val34 _Val36 _Val37 _Val38 : SortSet}
+    {_Val35 : SortKItem}
+    (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+    (defn_Val1 : lookup STORAGE_CELL W0 = some _Val1)
+    (defn_Val2 : lookup ORIG_STORAGE_CELL W0 = some _Val2)
+    (defn_Val3 : Csstore SCHEDULE_CELL W1 _Val1 _Val2 = some _Val3)
+    (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
+    (defn_Val5 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val5)
+    (defn_Val6 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val6)
+    (defn_Val7 : kite _Val5 0 _Val6 = some _Val7)
+    (defn_Val8 : lookup STORAGE_CELL W0 = some _Val8)
+    (defn_Val9 : lookup ORIG_STORAGE_CELL W0 = some _Val9)
+    (defn_Val10 : Csstore SCHEDULE_CELL W1 _Val8 _Val9 = some _Val10)
+    (defn_Val11 : «_-Int_» GAS_CELL _Val10 = some _Val11)
+    (defn_Val12 : «_<=Int_» _Val7 _Val11 = some _Val12)
+    (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+    (defn_Val14 : «_<Int_» _Val13 GAS_CELL = some _Val14)
+    (defn_Val15 : _andBool_ _Val12 _Val14 = some _Val15)
+    (defn_Val16 : _andBool_ _Val4 _Val15 = some _Val16)
+    (defn_Val17 : _andBool_ _Val0 _Val16 = some _Val17)
+    (defn_Val18 : _andBool_ USEGAS_CELL _Val17 = some _Val18)
+    (defn_Val19 : AccountCellMapItem { val := ID_CELL } {
+      acctID := { val := ID_CELL },
+      balance := _Gen23,
+      code := _Gen24,
+      storage := { val := STORAGE_CELL },
+      origStorage := { val := ORIG_STORAGE_CELL },
+      transientStorage := _Gen25,
+      nonce := _Gen26 } = some _Val19)
+    (defn_Val20 : _AccountCellMap_ _Val19 _DotVar6 = some _Val20)
+    (defn_Val21 : «_+Int_» PC_CELL 1 = some _Val21)
+    (defn_Val22 : lookup STORAGE_CELL W0 = some _Val22)
+    (defn_Val23 : lookup ORIG_STORAGE_CELL W0 = some _Val23)
+    (defn_Val24 : Csstore SCHEDULE_CELL W1 _Val22 _Val23 = some _Val24)
+    (defn_Val25 : «_-Int_» GAS_CELL _Val24 = some _Val25)
+    (defn_Val26 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val26)
+    (defn_Val27 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val27)
+    (defn_Val28 : kite _Val26 0 _Val27 = some _Val28)
+    (defn_Val29 : «_-Int_» _Val25 _Val28 = some _Val29)
+    (defn_Val30 : lookup STORAGE_CELL W0 = some _Val30)
+    (defn_Val31 : lookup ORIG_STORAGE_CELL W0 = some _Val31)
+    (defn_Val32 : Rsstore SCHEDULE_CELL W1 _Val30 _Val31 = some _Val32)
+    (defn_Val33 : «_+Int_» REFUND_CELL _Val32 = some _Val33)
+    (defn_Val34 : «.Set» = some _Val34)
+    (defn_Val35 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val34) = some _Val35)
+    (defn_Val36 : «project:Set» (SortK.kseq _Val35 SortK.dotk) = some _Val36)
+    (defn_Val37 : SetItem ((@inj SortInt SortKItem) W0) = some _Val37)
+    (defn_Val38 : «_|Set__SET_Set_Set_Set» _Val36 _Val37 = some _Val38)
+    (defn_Val39 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val38) = some _Val39)
+    (defn_Val40 : «Map:update» STORAGE_CELL ((@inj SortInt SortKItem) W0) ((@inj SortInt SortKItem) W1) = some _Val40)
+    (defn_Val41 : AccountCellMapItem { val := ID_CELL } {
+      acctID := { val := ID_CELL },
+      balance := _Gen23,
+      code := _Gen24,
+      storage := { val := _Val40 },
+      origStorage := { val := ORIG_STORAGE_CELL },
+      transientStorage := _Gen25,
+      nonce := _Gen26 } = some _Val41)
+    (defn_Val42 : _AccountCellMap_ _Val41 _DotVar6 = some _Val42)
+    (req : _Val18 = true)
+    : Rewrites {
+      kevm := {
+        k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortBinStackOp SortMaybeOpCode) SortBinStackOp.SSTORE_EVM_BinStackOp))) K_CELL },
+        exitCode := _Gen34,
+        mode := _Gen35,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := USEGAS_CELL },
+        ethereum := {
+          evm := {
+            output := _Gen13,
+            statusCode := _Gen14,
+            callStack := _Gen15,
+            interimStates := _Gen16,
+            touchedAccounts := _Gen17,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := { val := (@inj SortInt SortAccount) ID_CELL },
+              caller := _Gen2,
+              callData := _Gen3,
+              callValue := _Gen4,
+              wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W0 (SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W1 WS) },
+              localMem := _Gen5,
+              pc := { val := PC_CELL },
+              gas := { val := (@inj SortInt SortGas) GAS_CELL },
+              memoryUsed := _Gen6,
+              callGas := _Gen7,
+              static := { val := false },
+              callDepth := _Gen8 },
+            versionedHashes := _Gen18,
+            substate := {
+              selfDestruct := _Gen9,
+              log := _Gen10,
+              refund := { val := REFUND_CELL },
+              accessedAccounts := _Gen11,
+              accessedStorage := { val := ACCESSEDSTORAGE_CELL },
+              createdAccounts := _Gen12 },
+            gasPrice := _Gen19,
+            origin := _Gen20,
+            blockhashes := _Gen21,
+            block := _Gen22 },
+          network := {
+            chainID := _Gen27,
+            accounts := { val := _Val20 },
+            txOrder := _Gen28,
+            txPending := _Gen29,
+            messages := _Gen30,
+            withdrawalsPending := _Gen31,
+            withdrawalsOrder := _Gen32,
+            withdrawals := _Gen33 } } },
+      generatedCounter := _DotVar0 } {
+      kevm := {
+        k := { val := K_CELL },
+        exitCode := _Gen34,
+        mode := _Gen35,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := true },
+        ethereum := {
+          evm := {
+            output := _Gen13,
+            statusCode := _Gen14,
+            callStack := _Gen15,
+            interimStates := _Gen16,
+            touchedAccounts := _Gen17,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := { val := (@inj SortInt SortAccount) ID_CELL },
+              caller := _Gen2,
+              callData := _Gen3,
+              callValue := _Gen4,
+              wordStack := { val := WS },
+              localMem := _Gen5,
+              pc := { val := _Val21 },
+              gas := { val := (@inj SortInt SortGas) _Val29 },
+              memoryUsed := _Gen6,
+              callGas := _Gen7,
+              static := { val := false },
+              callDepth := _Gen8 },
+            versionedHashes := _Gen18,
+            substate := {
+              selfDestruct := _Gen9,
+              log := _Gen10,
+              refund := { val := _Val33 },
+              accessedAccounts := _Gen11,
+              accessedStorage := { val := _Val39 },
+              createdAccounts := _Gen12 },
+            gasPrice := _Gen19,
+            origin := _Gen20,
+            blockhashes := _Gen21,
+            block := _Gen22 },
+          network := {
+            chainID := _Gen27,
+            accounts := { val := _Val42 },
+            txOrder := _Gen28,
+            txPending := _Gen29,
+            messages := _Gen30,
+            withdrawalsPending := _Gen31,
+            withdrawalsOrder := _Gen32,
+            withdrawals := _Gen33 } } },
       generatedCounter := _DotVar0 }

--- a/EvmEquivalence/KEVM2Lean/ScheduleOrdering.lean
+++ b/EvmEquivalence/KEVM2Lean/ScheduleOrdering.lean
@@ -82,3 +82,38 @@ def toNat (sc : SortScheduleConst) : Nat :=
   | Gpointeval_SCHEDULE_ScheduleConst             => 4
 
 end SortScheduleConst
+
+namespace SortScheduleFlag
+
+def toNat (sf : SortScheduleFlag) : Nat :=
+  match sf with
+  | Gemptyisnonexistent_SCHEDULE_ScheduleFlag     => 1
+  | Ghasaccesslist_SCHEDULE_ScheduleFlag          => 1
+  | Ghasbasefee_SCHEDULE_ScheduleFlag             => 1
+  | Ghasbeaconroot_SCHEDULE_ScheduleFlag          => 1
+  | Ghasblobbasefee_SCHEDULE_ScheduleFlag         => 1
+  | Ghasblobhash_SCHEDULE_ScheduleFlag            => 1
+  | Ghaschainid_SCHEDULE_ScheduleFlag             => 1
+  | Ghascreate2_SCHEDULE_ScheduleFlag             => 1
+  | Ghasdirtysstore_SCHEDULE_ScheduleFlag         => 1
+  | Ghaseip6780_SCHEDULE_ScheduleFlag             => 1
+  | Ghasextcodehash_SCHEDULE_ScheduleFlag         => 1
+  | Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag     => 1
+  | Ghasmcopy_SCHEDULE_ScheduleFlag               => 1
+  | Ghasprevrandao_SCHEDULE_ScheduleFlag          => 1
+  | Ghaspushzero_SCHEDULE_ScheduleFlag            => 1
+  | Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag   => 1
+  | Ghasreturndata_SCHEDULE_ScheduleFlag          => 1
+  | Ghasrevert_SCHEDULE_ScheduleFlag              => 1
+  | Ghasselfbalance_SCHEDULE_ScheduleFlag         => 1
+  | Ghasshift_SCHEDULE_ScheduleFlag               => 1
+  | Ghassstorestipend_SCHEDULE_ScheduleFlag       => 1
+  | Ghasstaticcall_SCHEDULE_ScheduleFlag          => 1
+  | Ghastransient_SCHEDULE_ScheduleFlag           => 1
+  | Ghaswarmcoinbase_SCHEDULE_ScheduleFlag        => 1
+  | Ghaswithdrawals_SCHEDULE_ScheduleFlag         => 1
+  | Gselfdestructnewaccount_SCHEDULE_ScheduleFlag => 1
+  | Gstaticcalldepth_SCHEDULE_ScheduleFlag        => 1
+  | Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag => 1
+
+end SortScheduleFlag

--- a/EvmEquivalence/KEVM2Lean/Sorts.lean
+++ b/EvmEquivalence/KEVM2Lean/Sorts.lean
@@ -93,8 +93,40 @@ inductive SortTxType : Type where
   | «Legacy_EVM-TYPES_TxType» : SortTxType
   deriving BEq, DecidableEq
 
+inductive SortScheduleFlag : Type where
+  | Gemptyisnonexistent_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasaccesslist_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasbasefee_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasbeaconroot_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasblobbasefee_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasblobhash_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghaschainid_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghascreate2_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasdirtysstore_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghaseip6780_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasextcodehash_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasmcopy_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasprevrandao_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghaspushzero_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasreturndata_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasrevert_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasselfbalance_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasshift_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghassstorestipend_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghasstaticcall_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghastransient_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghaswarmcoinbase_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Ghaswithdrawals_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Gselfdestructnewaccount_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Gstaticcalldepth_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  | Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag : SortScheduleFlag
+  deriving BEq, DecidableEq
+
 inductive SortBinStackOp : Type where
   | ADD_EVM_BinStackOp : SortBinStackOp
+  | SSTORE_EVM_BinStackOp : SortBinStackOp
   deriving BEq, DecidableEq
 
 inductive SortMode : Type where
@@ -653,6 +685,7 @@ mutual
     | inj_SortSchedule (x : SortSchedule) : SortKItem
     | inj_SortScheduleCell (x : SortScheduleCell) : SortKItem
     | inj_SortScheduleConst (x : SortScheduleConst) : SortKItem
+    | inj_SortScheduleFlag (x : SortScheduleFlag) : SortKItem
     | inj_SortSelfDestructCell (x : SortSelfDestructCell) : SortKItem
     | inj_SortSet (x : SortSet) : SortKItem
     | inj_SortSigRCell (x : SortSigRCell) : SortKItem

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -133,10 +133,8 @@ noncomputable def accountMap (acc : SortAccountCell) : Account where
   code := accCodeMap acc.code.val
   tstorage := transStorageMap acc.transientStorage
 
---def mapMap (key value : Type) : Batteries.RBSet
-
 /--
-State Mapping: Mapping KEVM states to EvmYul states
+**State Mapping**: Mapping KEVM states to EvmYul states
 
 We temporarely require the `symState` argument since we don't map the entire KEVM state yet
 

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -10,6 +10,8 @@ import EvmEquivalence.Utils.IntUtils
 open EvmYul
 open EVM
 
+set_option linter.deprecated false
+
 /- Getters for accessing cells from the Generated Top Cell -/
 
 namespace SortGeneratedTopCell

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -51,6 +51,9 @@ def accounts : SortAccountsCell := tc.kevm.ethereum.network.accounts
 @[simp]
 def Iₐ : SortIdCell := tc.kevm.ethereum.evm.callState.id
 
+@[simp]
+def isStatic : SortStaticCell := tc.kevm.ethereum.evm.callState.static
+
 end SortGeneratedTopCell
 
 namespace SortKItem
@@ -151,7 +154,8 @@ noncomputable def stateMap (symState : EVM.State) (tc : SortGeneratedTopCell) : 
   gasAvailable := gasCellMap tc.gas
   executionEnv := {symState.executionEnv with
                 code := tc.program.val,
-                codeOwner := idMap tc.Iₐ}
+                codeOwner := idMap tc.Iₐ
+                perm := !tc.isStatic.val}
   accountMap := Axioms.SortAccountsCellMap tc.accounts
   substate := {symState.substate with
             accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap tc.accessedStorage

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -10,6 +10,47 @@ import EvmEquivalence.Utils.IntUtils
 open EvmYul
 open EVM
 
+/- Getters for accessing cells from the Generated Top Cell -/
+
+namespace SortGeneratedTopCell
+
+variable (tc : SortGeneratedTopCell)
+
+@[simp]
+def evm :SortEvmCell := tc.kevm.ethereum.evm
+
+@[simp]
+def callState : SortCallStateCell := tc.kevm.ethereum.evm.callState
+
+@[simp]
+def wordStackCell : SortWordStackCell := tc.kevm.ethereum.evm.callState.wordStack
+
+@[simp]
+def pc : SortPcCell := tc.kevm.ethereum.evm.callState.pc
+
+@[simp]
+def gas : SortGasCell := tc.kevm.ethereum.evm.callState.gas
+
+@[simp]
+def program : SortProgramCell := tc.kevm.ethereum.evm.callState.program
+
+@[simp]
+def output : SortOutputCell := tc.kevm.ethereum.evm.output
+
+@[simp]
+def accessedStorage : SortAccessedStorageCell := tc.kevm.ethereum.evm.substate.accessedStorage
+
+@[simp]
+def refund : SortRefundCell := tc.kevm.ethereum.evm.substate.refund
+
+@[simp]
+def accounts : SortAccountsCell := tc.kevm.ethereum.network.accounts
+
+@[simp]
+def Iₐ : SortIdCell := tc.kevm.ethereum.evm.callState.id
+
+end SortGeneratedTopCell
+
 namespace StateMap
 
 /- Maps from K types to EvmYul types -/
@@ -37,33 +78,17 @@ def gasMap (gs : SortGas) : UInt256 :=
 def gasCellMap (gc : SortGasCell) : UInt256 :=
   gasMap gc.val
 
-/- Getters for accessing cells from the Generated Top Cell -/
+@[simp]
 
 @[simp]
-def evmOfGTC (tc : SortGeneratedTopCell) :SortEvmCell :=
-  tc.kevm.ethereum.evm
 
 @[simp]
-def callStateOfGTC (tc : SortGeneratedTopCell) : SortCallStateCell :=
-  tc.kevm.ethereum.evm.callState
 
 @[simp]
-def wordStackCellOfGTC (tc : SortGeneratedTopCell) : SortWordStackCell :=
-  tc.kevm.ethereum.evm.callState.wordStack
 
 @[simp]
-def pcOfGTC (tc : SortGeneratedTopCell) : SortPcCell :=
-  tc.kevm.ethereum.evm.callState.pc
-
 @[simp]
-def gasOfGTC (tc : SortGeneratedTopCell) : SortGasCell :=
-  tc.kevm.ethereum.evm.callState.gas
 @[simp]
-def programOfGTC (tc : SortGeneratedTopCell) : SortProgramCell :=
-  tc.kevm.ethereum.evm.callState.program
-@[simp]
-def outputOfGTC (tc : SortGeneratedTopCell) : SortOutputCell :=
-  tc.kevm.ethereum.evm.output
 
 /- State Mapping: Mapping KEVM states to EvmYul states -/
 

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -4,6 +4,7 @@ import EvmEquivalence.KEVM2Lean.Inj
 import EvmEquivalence.KEVM2Lean.Func
 import EvmEquivalence.KEVM2Lean.Rewrite
 import EvmEquivalence.Interfaces.EvmYulInterface
+import EvmEquivalence.Interfaces.Axioms
 import EvmEquivalence.Utils.IntUtils
 
 open EvmYul

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -97,16 +97,41 @@ def gasCellMap (gc : SortGasCell) : UInt256 :=
   gasMap gc.val
 
 @[simp]
+def accountAddressMap (acc : SortAccount) : AccountAddress :=
+  match acc with
+  | .«.Account_EVM-TYPES_Account» => 0
+  | .inj_SortInt n => AccountAddress.ofNat (Int.toNat n)
 
 @[simp]
+def idMap (idc : SortIdCell) : AccountAddress :=
+  accountAddressMap idc.val
 
 @[simp]
+def acctIDMap (aid : SortAcctIDCell) : AccountAddress :=
+  AccountAddress.ofNat (Int.toNat aid.val)
 
 @[simp]
+noncomputable def storageMap (stor : SortStorageCell) : Storage :=
+  Axioms.SortStorageCellMap stor
 
 @[simp]
+noncomputable def transStorageMap (tstor : SortTransientStorageCell) : Storage :=
+  Axioms.SortTransientStorageCellMap tstor
+
 @[simp]
+def accCodeMap (code : SortAccountCode) : ByteArray :=
+  match code with | SortAccountCode.inj_SortBytes code => code
+
+/- Note that Origin Storage Cell (`origStorage`) is not needed from `SortAccountCell` -/
 @[simp]
+noncomputable def accountMap (acc : SortAccountCell) : Account where
+  nonce := intMap acc.nonce.val
+  balance := intMap acc.balance.val
+  storage := storageMap acc.storage
+  code := accCodeMap acc.code.val
+  tstorage := transStorageMap acc.transientStorage
+
+--def mapMap (key value : Type) : Batteries.RBSet
 
 /- State Mapping: Mapping KEVM states to EvmYul states -/
 

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -51,6 +51,24 @@ def Iₐ : SortIdCell := tc.kevm.ethereum.evm.callState.id
 
 end SortGeneratedTopCell
 
+namespace SortKItem
+
+/- KItem projections to subsorts -/
+@[simp]
+def toAccountSort (k : SortKItem) : Option SortAccount :=
+  match k with
+  | .inj_SortAccount acc => some acc
+  | _ => none
+
+/- Subsort projections to KItem -/
+@[simp]
+def ofAccountSort(acc : SortAccount) : SortKItem :=
+  SortKItem.inj_SortAccount acc
+
+end SortKItem
+
+open SortKItem
+
 namespace StateMap
 
 /- Maps from K types to EvmYul types -/

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -312,10 +312,16 @@ axiom accountsCell_map_insert
     transientStorage := tstorage,
     nonce := nonce } = some initAccount)
   (defn_Val20 : _AccountCellMap_ initAccount dotvar = some initCellMap)
-  (ownerAcc : Account)
   :
   Batteries.RBMap.insert (Axioms.SortAccountsCellMap { val := initCellMap }) (accountAddressMap (inj ID_CELL))
-    (ownerAcc.updateStorage (intMap key) (intMap value)) =
+    ((accountMap {
+    acctID := { val := ID_CELL },
+    balance := balance,
+    code := code,
+    storage := { val := STORAGE_CELL },
+    origStorage := { val := ORIG_STORAGE_CELL },
+    transientStorage := tstorage,
+    nonce := nonce }).updateStorage (intMap key) (intMap value)) =
   Axioms.SortAccountsCellMap { val := updatedCellMap }
 
 /--

--- a/EvmEquivalence/Summaries/AddSummary.lean
+++ b/EvmEquivalence/Summaries/AddSummary.lean
@@ -14,10 +14,10 @@ section
 variable (word₁ word₂ : UInt256)
 variable (gas gasCost : ℕ)
 variable (symStack : Stack UInt256)
-variable (symPc : UInt256)
-variable (symGasAvailable : UInt256)
+variable (symPc symGasAvailable symRefund : UInt256)
 variable (symExecLength : ℕ)
 variable (symReturnData symCode : ByteArray)
+variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
 
 abbrev addEVM := @Operation.ADD .EVM
 
@@ -46,6 +46,10 @@ theorem EVM.step_add_to_step_add (gpos : 0 < gas) (symState : EVM.State):
       gasAvailable := symGasAvailable,
       execLength := symExecLength,
       executionEnv := {symState.executionEnv with code := symCode},
+      substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
       returnData := symReturnData} =
   EvmYul.step_add
     {symState with
@@ -54,6 +58,10 @@ theorem EVM.step_add_to_step_add (gpos : 0 < gas) (symState : EVM.State):
     pc := symPc,
     executionEnv := {symState.executionEnv with code := symCode},
     returnData := symReturnData,
+    substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
     execLength := symExecLength + 1} := by
       cases gas; contradiction
       simp [EVM.step_add, EVM.step]; rfl
@@ -66,6 +74,10 @@ theorem EVM.step_add_summary (gpos : 0 < gas) (symState : EVM.State):
       gasAvailable := symGasAvailable,
       returnData := symReturnData,
       executionEnv := {symState.executionEnv with code := symCode},
+      substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
       execLength := symExecLength} =
     .ok {symState with
           stack := (word₁ + word₂) :: symStack,
@@ -73,6 +85,10 @@ theorem EVM.step_add_summary (gpos : 0 < gas) (symState : EVM.State):
           gasAvailable := symGasAvailable - UInt256.ofNat gasCost,
           returnData := symReturnData,
           executionEnv := {symState.executionEnv with code := symCode},
+          substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
           execLength := symExecLength + 1} := by
   rw [EVM.step_add_to_step_add]; rfl; assumption
 
@@ -126,6 +142,10 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
     execLength := symExecLength,
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with code := ⟨#[(0x1 : UInt8)]⟩}
+    substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
     returnData := symReturnData} =
   Except.ok (.success {symState with
         stack := (word₁ + word₂) :: symStack,
@@ -133,6 +153,10 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
         gasAvailable := symGasAvailable - .ofNat GasConstants.Gverylow,
         executionEnv := {symState.executionEnv with code := ⟨#[(0x1 : UInt8)]⟩},
         returnData := ByteArray.empty,
+        substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
         execLength := symExecLength + 2} ByteArray.empty):= by
   cases g_case : symGasAvailable.toNat; rw [g_case] at enoughGas; contradiction
   case succ g_pos =>
@@ -146,7 +170,7 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
   split; contradiction
   case h_2 evm _ stateOk =>
   have gPos : (0 < g_pos) := by aesop (add simp [GasConstants.Gverylow]) (add safe (by omega))
-  have step_rw := (EVM.step_add_summary word₁ word₂ g_pos GasConstants.Gverylow symStack (.ofNat 0) symGasAvailable symExecLength symReturnData ⟨#[(0x1 : UInt8)]⟩ gPos evm)
+  have step_rw := (EVM.step_add_summary word₁ word₂ g_pos GasConstants.Gverylow symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x1 : UInt8)]⟩ symAccessedStorageKeys gPos evm)
   cases stateOk; rw [←EVM.step_add, step_rw]; simp [Except.instMonad, Except.bind]
   rw [X_bad_pc] <;> aesop (add simp [GasConstants.Gverylow]) (add safe (by omega))
 

--- a/EvmEquivalence/Summaries/AddSummary.lean
+++ b/EvmEquivalence/Summaries/AddSummary.lean
@@ -20,6 +20,7 @@ variable (symReturnData symCode : ByteArray)
 variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
 variable (symAccounts : AccountMap)
 variable (symCodeOwner : AccountAddress)
+variable (symPerm : Bool)
 
 abbrev addEVM := @Operation.ADD .EVM
 
@@ -49,7 +50,8 @@ theorem EVM.step_add_to_step_add (gpos : 0 < gas) (symState : EVM.State):
       execLength := symExecLength,
       executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
       accountMap := symAccounts
       substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -63,7 +65,8 @@ theorem EVM.step_add_to_step_add (gpos : 0 < gas) (symState : EVM.State):
     pc := symPc,
     executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
     accountMap := symAccounts
     returnData := symReturnData,
     substate := {symState.substate with
@@ -83,7 +86,8 @@ theorem EVM.step_add_summary (gpos : 0 < gas) (symState : EVM.State):
       returnData := symReturnData,
       executionEnv := {symState.executionEnv with
                     code := symCode,
-                    codeOwner := symCodeOwner},
+                    codeOwner := symCodeOwner,
+                    perm := symPerm},
       accountMap := symAccounts
       substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -97,7 +101,8 @@ theorem EVM.step_add_summary (gpos : 0 < gas) (symState : EVM.State):
           returnData := symReturnData,
           executionEnv := {symState.executionEnv with
                         code := symCode,
-                        codeOwner := symCodeOwner},
+                        codeOwner := symCodeOwner,
+                        perm := symPerm},
           accountMap := symAccounts
           substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -157,7 +162,8 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with
                   code := ⟨#[(0x1 : UInt8)]⟩,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
     accountMap := symAccounts
     substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -170,7 +176,8 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
         gasAvailable := symGasAvailable - .ofNat GasConstants.Gverylow,
         executionEnv := {symState.executionEnv with
                   code := ⟨#[(0x1 : UInt8)]⟩,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
         accountMap := symAccounts
         returnData := ByteArray.empty,
         substate := {symState.substate with
@@ -190,7 +197,7 @@ theorem X_add_summary (enoughGas : GasConstants.Gverylow < symGasAvailable.toNat
   split; contradiction
   case h_2 evm _ stateOk =>
   have gPos : (0 < g_pos) := by aesop (add simp [GasConstants.Gverylow]) (add safe (by omega))
-  have step_rw := (EVM.step_add_summary word₁ word₂ g_pos GasConstants.Gverylow symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x1 : UInt8)]⟩ symAccessedStorageKeys symAccounts symCodeOwner gPos evm)
+  have step_rw := (EVM.step_add_summary word₁ word₂ g_pos GasConstants.Gverylow symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x1 : UInt8)]⟩ symAccessedStorageKeys symAccounts symCodeOwner symPerm gPos evm)
   cases stateOk; rw [←EVM.step_add, step_rw]; simp [Except.instMonad, Except.bind]
   rw [X_bad_pc] <;> aesop (add simp [GasConstants.Gverylow]) (add safe (by omega))
 

--- a/EvmEquivalence/Summaries/Push0Summary.lean
+++ b/EvmEquivalence/Summaries/Push0Summary.lean
@@ -19,6 +19,7 @@ variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) S
 variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
 variable (symAccounts : AccountMap)
 variable (symCodeOwner : AccountAddress)
+variable (symPerm : Bool)
 
 @[simp]
 abbrev push0EVM := @Operation.PUSH0
@@ -57,7 +58,8 @@ theorem EVM.step_push0_summary (gpos : 0 < gas) (symState : EVM.State):
       gasAvailable := symGasAvailable,
       executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
       accountMap := symAccounts
       substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -71,7 +73,8 @@ theorem EVM.step_push0_summary (gpos : 0 < gas) (symState : EVM.State):
     pc := symPc + .ofNat 1,
     executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
     accountMap := symAccounts,
     substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -104,7 +107,8 @@ theorem X_push0_summary (enoughGas : GasConstants.Gbase < symGasAvailable.toNat)
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with
                   code := ⟨#[(0x5F : UInt8)]⟩,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
     accountMap := symAccounts,
     substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -118,7 +122,8 @@ theorem X_push0_summary (enoughGas : GasConstants.Gbase < symGasAvailable.toNat)
         gasAvailable := symGasAvailable - .ofNat GasConstants.Gbase,
         executionEnv := {symState.executionEnv with
                   code := ⟨#[(0x5F : UInt8)]⟩,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner,
+                  perm := symPerm},
         accountMap := symAccounts,
         substate := {symState.substate with
             accessedStorageKeys :=  symAccessedStorageKeys
@@ -137,7 +142,7 @@ theorem X_push0_summary (enoughGas : GasConstants.Gbase < symGasAvailable.toNat)
   rename_i evm _ stateOk; revert stateOk
   simp [pure, Except.pure]; intro evm_eq cost; subst cost evm_eq
   dsimp [Except.instMonad, Except.bind]
-  have step_rw := (@EVM.step_push0_summary g_pos GasConstants.Gbase symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x5F : UInt8)]⟩ symAccessedStorageKeys symAccounts symCodeOwner gPos)
+  have step_rw := (@EVM.step_push0_summary g_pos GasConstants.Gbase symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x5F : UInt8)]⟩ symAccessedStorageKeys symAccounts symCodeOwner symPerm gPos)
   rw [EVM.step_push0, push0_instr] at step_rw; simp [step_rw]
   rw [X_bad_pc] <;> aesop (add simp [GasConstants.Gbase]) (add safe (by omega))
 

--- a/EvmEquivalence/Summaries/Push0Summary.lean
+++ b/EvmEquivalence/Summaries/Push0Summary.lean
@@ -12,10 +12,10 @@ section
 
 variable (gas gasCost : ℕ)
 variable (symStack : Stack UInt256)
-variable (symPc : UInt256)
-variable (symGasAvailable : UInt256)
+variable (symPc symGasAvailable symRefund : UInt256)
 variable (symExecLength : ℕ)
 variable (symReturnData symCode : ByteArray)
+variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
 
 @[simp]
 abbrev push0EVM := @Operation.PUSH0
@@ -52,14 +52,22 @@ theorem EVM.step_push0_summary (gpos : 0 < gas) (symState : EVM.State):
       stack := symStack,
       pc := symPc,
       gasAvailable := symGasAvailable,
-      execLength := symExecLength,
       executionEnv := {symState.executionEnv with code := symCode},
-      returnData := symReturnData} =
+      substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
+      returnData := symReturnData,
+      execLength := symExecLength} =
     .ok {symState with
     stack := (.ofNat 0) :: symStack
     gasAvailable := symGasAvailable - UInt256.ofNat gasCost
     pc := symPc + .ofNat 1,
     executionEnv := {symState.executionEnv with code := symCode},
+    substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
     returnData := symReturnData,
     execLength := symExecLength + 1} := by
   cases gas; contradiction; rfl
@@ -84,15 +92,23 @@ theorem X_push0_summary (enoughGas : GasConstants.Gbase < symGasAvailable.toNat)
   {symState with
     stack := symStack,
     pc := .ofNat 0,
-    execLength := symExecLength,
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with code := ⟨#[(0x5F : UInt8)]⟩}
-    returnData := symReturnData} =
+    substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
+    returnData := symReturnData,
+    execLength := symExecLength} =
   Except.ok (.success {symState with
         stack := (.ofNat 0) :: symStack,
         pc := .ofNat 1,
         gasAvailable := symGasAvailable - .ofNat GasConstants.Gbase,
         executionEnv := {symState.executionEnv with code := ⟨#[(0x5F : UInt8)]⟩},
+        substate := {symState.substate with
+            accessedStorageKeys :=  symAccessedStorageKeys
+            refundBalance := symRefund
+           }
         returnData := ByteArray.empty,
         execLength := symExecLength + 2} ByteArray.empty):= by
   cases g_case: symGasAvailable.toNat; rw [g_case] at enoughGas; contradiction
@@ -106,7 +122,7 @@ theorem X_push0_summary (enoughGas : GasConstants.Gbase < symGasAvailable.toNat)
   rename_i evm _ stateOk; revert stateOk
   simp [pure, Except.pure]; intro evm_eq cost; subst cost evm_eq
   dsimp [Except.instMonad, Except.bind]
-  have step_rw := (@EVM.step_push0_summary g_pos GasConstants.Gbase symStack (.ofNat 0) symGasAvailable symExecLength symReturnData ⟨#[(0x5F : UInt8)]⟩ gPos)
+  have step_rw := (@EVM.step_push0_summary g_pos GasConstants.Gbase symStack (.ofNat 0) symGasAvailable symRefund symExecLength symReturnData ⟨#[(0x5F : UInt8)]⟩ symAccessedStorageKeys gPos)
   rw [EVM.step_push0, push0_instr] at step_rw; simp [step_rw]
   rw [X_bad_pc] <;> aesop (add simp [GasConstants.Gbase]) (add safe (by omega))
 

--- a/EvmEquivalence/Summaries/SstoreSummary.lean
+++ b/EvmEquivalence/Summaries/SstoreSummary.lean
@@ -1,0 +1,100 @@
+import EvmYul.EVM.Semantics
+import EvmYul.EVM.GasConstants
+--import EvmEquivalence.Summaries.StopSummary
+import EvmEquivalence.Interfaces.EvmYulInterface
+
+open EvmYul
+open EVM
+open EvmYul.State
+
+namespace SstoreSummary
+
+section
+
+variable (gas gasCost : ℕ)
+variable (symStack : Stack UInt256)
+variable (symPc : UInt256)
+variable (symGasAvailable key value : UInt256)
+variable (symExecLength : ℕ)
+variable (symReturnData symCode : ByteArray)
+
+@[simp]
+abbrev sstoreEVM := @Operation.SSTORE .EVM
+
+@[simp]
+abbrev sstore_instr : Option (Operation .EVM × Option (UInt256 × Nat)) :=
+  some ⟨sstoreEVM, none⟩
+
+@[simp]
+def EVM.step_sstore : Transformer :=
+  EVM.step false gas gasCost sstore_instr
+
+@[simp]
+def EvmYul.step_sstore : Transformer :=
+  EvmYul.step false sstoreEVM
+
+/--
+Theorem needed to bypass the `private` attribute of `EVM.dispatchBinaryStateOp`
+ -/
+theorem sstore_bypass_private {symState : EVM.State}:
+  EvmYul.step_sstore symState =
+  EVM.binaryStateOp false EvmYul.State.sstore symState := rfl
+
+/- This probably should be deleted -/
+theorem sstore_rw {symState : EVM.State} {key value : UInt256}:
+  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
+  let Iₐ := symState.toState.executionEnv.codeOwner
+  (Option.option symState.toState (λ acc ↦
+    let self' :=
+      symState.toState.setAccount Iₐ (Account.updateStorage acc key value)
+        |>.addAccessedStorageKey (Iₐ, key)
+    { self' with substate.refundBalance := Aᵣ}))
+    (State.lookupAccount symState.toState Iₐ):= by aesop
+
+theorem sstore_summary {symState : EVM.State} {key value : UInt256}:
+  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
+  let Iₐ := symState.toState.executionEnv.codeOwner
+  let ownerAcc := (State.lookupAccount symState.toState Iₐ)
+  match ownerAcc with
+  | none =>
+    {symState with
+      accountMap := symState.toState.accountMap
+      substate.accessedStorageKeys := symState.substate.accessedStorageKeys
+      substate.refundBalance := Aᵣ
+    }
+  | some ownerAcc =>
+    {symState with
+      accountMap := symState.accountMap.insert Iₐ (Account.updateStorage (ownerAcc) key value)
+      substate.accessedStorageKeys := symState.substate.accessedStorageKeys.insert ⟨Iₐ, key⟩
+      substate.refundBalance := Aᵣ
+    } := by
+  cases cco: (symState.lookupAccount symState.toState.executionEnv.codeOwner)
+  all_goals aesop (add simp [sstore])
+
+theorem EvmYul.step_sstore_summary (symState : EVM.State):
+  EvmYul.step_sstore {symState with
+    stack := key :: value :: symStack,
+    pc := symPc} =
+  .ok {symState with
+    stack := symStack,
+    pc := symPc + .ofNat 1} := by
+  rw [sstore_bypass_private]
+  simp [binaryStateOp, Stack.pop2, Id.run, State.replaceStackAndIncrPC, State.incrPC]
+  have sstoreRw := @sstore_rw symState key value
+  rcases sstoreRw; case intro gas ss_rw =>
+  simp [ss_rw]
+  rw [sstore_rw]
+  simp [State.addAccessedStorageKey, Account.updateStorage, State.setAccount]
+  cases value_default : (value == default) <;> simp
+  case false =>
+
+
+  simp [Batteries.RBMap.insert, Batteries.RBSet.insert, Batteries.RBNode.insert]
+  --simp [EvmYul.step, Id.run]
+  --simp [Id.run]
+  rw [step_sstore_rw]
+
+
+end
+
+end SstoreSummary

--- a/EvmEquivalence/Summaries/SstoreSummary.lean
+++ b/EvmEquivalence/Summaries/SstoreSummary.lean
@@ -19,6 +19,7 @@ variable (symReturnData symCode : ByteArray)
 variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
 variable (symAccounts : AccountMap)
 variable (symCodeOwner : AccountAddress)
+variable (symPerm : Bool)
 
 @[simp]
 abbrev sstoreEVM := @Operation.SSTORE .EVM
@@ -45,7 +46,8 @@ theorem sstore_bypass_private (symState : EVM.State):
   gasAvailable := symGasAvailable,
   executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
   substate := {symState.substate with
                accessedStorageKeys :=  symAccessedStorageKeys
                refundBalance := symRefund}
@@ -110,7 +112,8 @@ theorem sstore_summary (symState : EvmYul.State) (key value : UInt256):
   let ss := {symState with
              executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
              substate := {symState.substate with
                           accessedStorageKeys :=  symAccessedStorageKeys
                           refundBalance := symRefund}
@@ -130,7 +133,8 @@ theorem EvmYul.step_sstore_summary (symState : EVM.State):
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
     substate := {symState.substate with
                  accessedStorageKeys :=  symAccessedStorageKeys
                  refundBalance := symRefund}
@@ -154,7 +158,8 @@ theorem EVM.step_sstore_summary (gas_pos : 0 < gas) (symState : EVM.State):
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with
                   code := symCode,
-                  codeOwner := symCodeOwner},
+                  codeOwner := symCodeOwner
+                  perm := true},
     substate := {symState.substate with
                  accessedStorageKeys :=  symAccessedStorageKeys
                  refundBalance := symRefund}

--- a/EvmEquivalence/Summaries/SstoreSummary.lean
+++ b/EvmEquivalence/Summaries/SstoreSummary.lean
@@ -40,60 +40,47 @@ theorem sstore_bypass_private {symState : EVM.State}:
   EvmYul.step_sstore symState =
   EVM.binaryStateOp false EvmYul.State.sstore symState := rfl
 
-/- This probably should be deleted -/
-theorem sstore_rw {symState : EVM.State} {key value : UInt256}:
-  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
-  let Iₐ := symState.toState.executionEnv.codeOwner
-  (Option.option symState.toState (λ acc ↦
-    let self' :=
-      symState.toState.setAccount Iₐ (Account.updateStorage acc key value)
-        |>.addAccessedStorageKey (Iₐ, key)
-    { self' with substate.refundBalance := Aᵣ}))
-    (State.lookupAccount symState.toState Iₐ):= by aesop
-
-theorem sstore_summary {symState : EVM.State} {key value : UInt256}:
-  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
+@[simp]
+def accountMap_sstore (symState : EVM.State) (key value : UInt256) : AccountMap :=
   let Iₐ := symState.toState.executionEnv.codeOwner
   let ownerAcc := (State.lookupAccount symState.toState Iₐ)
   match ownerAcc with
-  | none =>
-    {symState with
-      accountMap := symState.toState.accountMap
-      substate.accessedStorageKeys := symState.substate.accessedStorageKeys
-      substate.refundBalance := Aᵣ
-    }
+  | none => symState.toState.accountMap
   | some ownerAcc =>
+    symState.accountMap.insert Iₐ (Account.updateStorage (ownerAcc) key value)
+
+@[simp]
+def accessedStorageKeys_sstore (symState : EVM.State) (key : UInt256) :=
+  let Iₐ := symState.toState.executionEnv.codeOwner
+  let ownerAcc := (State.lookupAccount symState.toState Iₐ)
+  match ownerAcc with
+  | none => symState.substate.accessedStorageKeys
+  | some _ => symState.substate.accessedStorageKeys.insert ⟨Iₐ, key⟩
+
+theorem sstore_summary (symState : EVM.State) (key value : UInt256):
+  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
     {symState with
-      accountMap := symState.accountMap.insert Iₐ (Account.updateStorage (ownerAcc) key value)
-      substate.accessedStorageKeys := symState.substate.accessedStorageKeys.insert ⟨Iₐ, key⟩
+      accountMap := accountMap_sstore symState key value
+      substate.accessedStorageKeys := accessedStorageKeys_sstore symState key
       substate.refundBalance := Aᵣ
     } := by
   cases cco: (symState.lookupAccount symState.toState.executionEnv.codeOwner)
   all_goals aesop (add simp [sstore])
 
 theorem EvmYul.step_sstore_summary (symState : EVM.State):
+  ∃ Aᵣ: UInt256,
   EvmYul.step_sstore {symState with
     stack := key :: value :: symStack,
     pc := symPc} =
   .ok {symState with
     stack := symStack,
+    accountMap := accountMap_sstore symState key value
+    substate.accessedStorageKeys := accessedStorageKeys_sstore symState key
+    substate.refundBalance := Aᵣ
     pc := symPc + .ofNat 1} := by
   rw [sstore_bypass_private]
   simp [binaryStateOp, Stack.pop2, Id.run, State.replaceStackAndIncrPC, State.incrPC]
-  have sstoreRw := @sstore_rw symState key value
-  rcases sstoreRw; case intro gas ss_rw =>
-  simp [ss_rw]
-  rw [sstore_rw]
-  simp [State.addAccessedStorageKey, Account.updateStorage, State.setAccount]
-  cases value_default : (value == default) <;> simp
-  case false =>
-
-
-  simp [Batteries.RBMap.insert, Batteries.RBSet.insert, Batteries.RBNode.insert]
-  --simp [EvmYul.step, Id.run]
-  --simp [Id.run]
-  rw [step_sstore_rw]
-
+  have _ := sstore_summary symState key value; aesop
 
 end
 

--- a/EvmEquivalence/Summaries/SstoreSummary.lean
+++ b/EvmEquivalence/Summaries/SstoreSummary.lean
@@ -13,10 +13,12 @@ section
 
 variable (gas gasCost : ℕ)
 variable (symStack : Stack UInt256)
-variable (symPc : UInt256)
-variable (symGasAvailable key value : UInt256)
+variable (symPc symGasAvailable symRefund key value : UInt256)
 variable (symExecLength : ℕ)
 variable (symReturnData symCode : ByteArray)
+variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
+variable (symAccounts : AccountMap)
+variable (symCodeOwner : AccountAddress)
 
 @[simp]
 abbrev sstoreEVM := @Operation.SSTORE .EVM
@@ -26,61 +28,154 @@ abbrev sstore_instr : Option (Operation .EVM × Option (UInt256 × Nat)) :=
   some ⟨sstoreEVM, none⟩
 
 @[simp]
-def EVM.step_sstore : Transformer :=
+abbrev EVM.step_sstore : Transformer :=
   EVM.step false gas gasCost sstore_instr
 
 @[simp]
-def EvmYul.step_sstore : Transformer :=
+abbrev EvmYul.step_sstore : Transformer :=
   EvmYul.step false sstoreEVM
 
 /--
 Theorem needed to bypass the `private` attribute of `EVM.dispatchBinaryStateOp`
  -/
-theorem sstore_bypass_private {symState : EVM.State}:
-  EvmYul.step_sstore symState =
-  EVM.binaryStateOp false EvmYul.State.sstore symState := rfl
+theorem sstore_bypass_private (symState : EVM.State):
+  let ss := {symState with
+  stack := key :: value :: symStack,
+  pc := symPc
+  gasAvailable := symGasAvailable,
+  executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner},
+  substate := {symState.substate with
+               accessedStorageKeys :=  symAccessedStorageKeys
+               refundBalance := symRefund}
+  returnData := symReturnData,
+  execLength := symExecLength,
+  accountMap := symAccounts}
+  EvmYul.step_sstore ss =
+  EVM.binaryStateOp false EvmYul.State.sstore ss := rfl
 
 @[simp]
-def accountMap_sstore (symState : EVM.State) (key value : UInt256) : AccountMap :=
-  let Iₐ := symState.toState.executionEnv.codeOwner
-  let ownerAcc := (State.lookupAccount symState.toState Iₐ)
+def accountMap_sstore (symState : EvmYul.State) (key value : UInt256) : AccountMap :=
+  let Iₐ := symState.executionEnv.codeOwner
+  let ownerAcc := (State.lookupAccount symState Iₐ)
   match ownerAcc with
-  | none => symState.toState.accountMap
+  | none => symState.accountMap
   | some ownerAcc =>
     symState.accountMap.insert Iₐ (Account.updateStorage (ownerAcc) key value)
 
 @[simp]
-def accessedStorageKeys_sstore (symState : EVM.State) (key : UInt256) :=
-  let Iₐ := symState.toState.executionEnv.codeOwner
-  let ownerAcc := (State.lookupAccount symState.toState Iₐ)
+def accessedStorageKeys_sstore (symState : EvmYul.State) (key : UInt256) :=
+  let Iₐ := symState.executionEnv.codeOwner
+  let ownerAcc := (State.lookupAccount symState Iₐ)
   match ownerAcc with
   | none => symState.substate.accessedStorageKeys
   | some _ => symState.substate.accessedStorageKeys.insert ⟨Iₐ, key⟩
 
-theorem sstore_summary (symState : EVM.State) (key value : UInt256):
-  ∃ Aᵣ: UInt256, State.sstore symState.toState key value =
-    {symState with
-      accountMap := accountMap_sstore symState key value
-      substate.accessedStorageKeys := accessedStorageKeys_sstore symState key
-      substate.refundBalance := Aᵣ
-    } := by
-  cases cco: (symState.lookupAccount symState.toState.executionEnv.codeOwner)
-  all_goals aesop (add simp [sstore])
+-- From EvmYul.StateOps.sstore
+@[local simp]
+def Aᵣ_sstore (symState: EvmYul.State) (key val : UInt256) : UInt256 :=
+    let Iₐ := symState.executionEnv.codeOwner
+  let { storage := σ_Iₐ, .. } := symState.accountMap.find! Iₐ
+  let { storage := σ₀_Iₐ, .. } := symState.σ₀.find! Iₐ
+  let v₀ := σ₀_Iₐ.findD key ⟨0⟩
+  let v := σ_Iₐ.findD key ⟨0⟩
+  let v' := val
+
+  let r_dirtyclear : ℤ :=
+    if v₀ ≠ .ofNat 0 && v = .ofNat 0 then - GasConstants.Rsclear else
+    if v₀ ≠ .ofNat 0 && v' = .ofNat 0 then GasConstants.Rsclear else
+    0
+
+  let r_dirtyreset : ℤ :=
+    if v₀ = v' && v₀ = .ofNat 0 then GasConstants.Gsset - GasConstants.Gwarmaccess else
+    if v₀ = v' && v₀ ≠ .ofNat 0 then GasConstants.Gsreset - GasConstants.Gwarmaccess else
+    0
+
+  let ΔAᵣ : ℤ :=
+    if v ≠ v' && v₀ = v && v' = .ofNat 0 then GasConstants.Rsclear else
+    if v ≠ v' && v₀ ≠ v then r_dirtyclear + r_dirtyreset else
+    0
+
+  let Iₐ := symState.executionEnv.codeOwner
+  let ownerAcc := (State.lookupAccount symState Iₐ)
+  match ownerAcc with
+  | none => symState.substate.refundBalance
+  | some _ =>
+    match ΔAᵣ with
+        | .ofNat n => symState.substate.refundBalance + .ofNat n
+        | .negSucc n => symState.substate.refundBalance - .ofNat n - ⟨1⟩
+
+theorem sstore_summary (symState : EvmYul.State) (key value : UInt256):
+  let ss := {symState with
+             executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner},
+             substate := {symState.substate with
+                          accessedStorageKeys :=  symAccessedStorageKeys
+                          refundBalance := symRefund}
+             accountMap := symAccounts}
+  State.sstore ss key value =
+  {ss with
+    accountMap := accountMap_sstore ss key value,
+    substate.accessedStorageKeys := accessedStorageKeys_sstore ss key,
+    substate.refundBalance := Aᵣ_sstore ss key value} := by
+  cases cco: (symState.lookupAccount symState.executionEnv.codeOwner)
+  all_goals aesop (add simp [sstore, Aᵣ_sstore, Option.option, lookupAccount])
 
 theorem EvmYul.step_sstore_summary (symState : EVM.State):
-  ∃ Aᵣ: UInt256,
-  EvmYul.step_sstore {symState with
+  let ss := {symState with
     stack := key :: value :: symStack,
-    pc := symPc} =
-  .ok {symState with
+    pc := symPc
+    gasAvailable := symGasAvailable,
+    executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner},
+    substate := {symState.substate with
+                 accessedStorageKeys :=  symAccessedStorageKeys
+                 refundBalance := symRefund}
+    returnData := symReturnData,
+    execLength := symExecLength,
+    accountMap := symAccounts}
+  EvmYul.step_sstore ss =
+  .ok {ss with
     stack := symStack,
-    accountMap := accountMap_sstore symState key value
-    substate.accessedStorageKeys := accessedStorageKeys_sstore symState key
-    substate.refundBalance := Aᵣ
-    pc := symPc + .ofNat 1} := by
-  rw [sstore_bypass_private]
-  simp [binaryStateOp, Stack.pop2, Id.run, State.replaceStackAndIncrPC, State.incrPC]
-  have _ := sstore_summary symState key value; aesop
+    pc := symPc + .ofNat 1
+    accountMap := accountMap_sstore ss.toState key value
+    substate.accessedStorageKeys := accessedStorageKeys_sstore ss.toState key
+    substate.refundBalance := Aᵣ_sstore ss.toState key value} := by
+  simp [sstore_bypass_private, binaryStateOp, Stack.pop2, Id.run, State.replaceStackAndIncrPC, State.incrPC]
+  aesop (add simp [sstore_summary])
+
+theorem EVM.step_sstore_summary (gas_pos : 0 < gas) (symState : EVM.State):
+  let ss := {symState with
+    stack := key :: value :: symStack,
+    pc := symPc
+    gasAvailable := symGasAvailable,
+    executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner},
+    substate := {symState.substate with
+                 accessedStorageKeys :=  symAccessedStorageKeys
+                 refundBalance := symRefund}
+    returnData := symReturnData,
+    execLength := symExecLength,
+    accountMap := symAccounts}
+  EVM.step_sstore gas gasCost ss =
+    .ok {ss with
+          stack := symStack,
+          pc := symPc + (.ofNat 1),
+          gasAvailable := symGasAvailable - UInt256.ofNat gasCost,
+          accountMap := accountMap_sstore ss.toState key value
+          substate := {ss.substate with
+            accessedStorageKeys := accessedStorageKeys_sstore ss.toState key
+            refundBalance := Aᵣ_sstore ss.toState key value
+           }
+          execLength := symExecLength + 1} := by
+  cases gas; contradiction
+  simp [step_sstore, EVM.step]
+  have srw := EvmYul.step_sstore_summary symStack symPc (symGasAvailable - UInt256.ofNat gasCost) symRefund key value (symExecLength + 1) symReturnData symCode
+  simp [EvmYul.step_sstore, Operation.SSTORE] at srw; aesop
 
 end
 

--- a/README.md
+++ b/README.md
@@ -18,10 +18,10 @@ To this end, the K framework allows for the generation of Lean 4 code representi
 Under [EvmEquivalence](./EvmEquivalence) we have the following structure:
 * [KEVM2Lean](./EvmEquivalence/KEVM2Lean): K-generated Lean 4 code with modifications
 * [Interfaces](./EvmEquivalence/Interfaces): Proving interfaces to interact with the K-generated Lean 4 code
+* [Summaries](./EvmEquivalence/Summaries): Summaries of relevant functions from the `EvmYul` model
+* [Equivalence](./EvmEquivalence/Equivalence): Proof of equivalence between the models in a per-opcode basis
 * [Utils](./EvmEquivalence/Utils): Useful results for the proving
-* [Summaries.lean](./EvmEquivalence/Summaries.lean): Summaries of relevant functions from the `EvmYul` model
 * [StateMap.lean](./EvmEquivalence/StateMap.lean): Function mapping `KEVM` states to `EvmYul` states
-* [AddEquivalence.lean](./EvmEquivalence/AddEquivalence.lean): Proof of equivalence between the models for the `ADD` opcode
 
 ## Lean 4 Code Generation
 

--- a/lakefile.toml
+++ b/lakefile.toml
@@ -1,6 +1,6 @@
 name = "evm-equivalence"
 version = "0.1.0"
-defaultTargets = ["EvmEquivalence*"]
+defaultTargets = ["EvmEquivalence"]
 
 [leanOptions]
 pp.unicode.fun = true # pretty-prints `fun a ↦ b`


### PR DESCRIPTION
This PR adds the following:

- Equivalence proofs for the `SSTORE` opcode
- Improved project documentation, especially in the `Equivalence` and `Interfaces` folders
- Interface for the `«_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule»` function
- Axiomatic description of the `KEVM --> EvmYul` mapping
  - Axiomatic mapping added in `Interfaces/Axioms.lean`
  - Expected behavior of the axiomatic mapping described in the `Axioms` namespace of `StateMap.lean`
- Expanded `stateMap` function to account for the broader subset of the semantics that the `SSTORE` opcode exercises
- Necessary modules in the `EvmEquivalence.lean` file to enable building with `lake build`