### PR TITLE
`SLOAD` opcode equivalence

### DIFF
--- a/EvmEquivalence/Equivalence/SloadEquivalence.lean
+++ b/EvmEquivalence/Equivalence/SloadEquivalence.lean
@@ -1,0 +1,711 @@
+import EvmEquivalence.Summaries.SloadSummary
+import EvmEquivalence.Interfaces.EvmYulInterface
+import EvmEquivalence.Interfaces.GasInterface
+import EvmEquivalence.Interfaces.FuncInterface
+import EvmEquivalence.StateMap
+
+open EvmYul
+open StateMap
+open KEVMInterface
+open SloadSummary
+
+namespace SloadOpcodeEquivalence
+
+def sloadLHS
+  {ACCESSEDSTORAGE_CELL : SortMap}
+  {GAS_CELL ID_CELL PC_CELL W0 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell} : SortGeneratedTopCell :=
+  {kevm := {
+        k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortUnStackOp SortMaybeOpCode) SortUnStackOp.SLOAD_EVM_UnStackOp))) K_CELL },
+        exitCode := _Gen37,
+        mode := _Gen38,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := USEGAS_CELL },
+        ethereum := {
+          evm := {
+            output := _Gen15,
+            statusCode := _Gen16,
+            callStack := _Gen17,
+            interimStates := _Gen18,
+            touchedAccounts := _Gen19,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := { val := (@inj SortInt SortAccount) ID_CELL },
+              caller := _Gen2,
+              callData := _Gen3,
+              callValue := _Gen4,
+              wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W0 WS },
+              localMem := _Gen5,
+              pc := { val := PC_CELL },
+              gas := { val := (@inj SortInt SortGas) GAS_CELL },
+              memoryUsed := _Gen6,
+              callGas := _Gen7,
+              static := _Gen8,
+              callDepth := _Gen9 },
+            versionedHashes := _Gen20,
+            substate := {
+              selfDestruct := _Gen10,
+              log := _Gen11,
+              refund := _Gen12,
+              accessedAccounts := _Gen13,
+              accessedStorage := { val := ACCESSEDSTORAGE_CELL },
+              createdAccounts := _Gen14 },
+            gasPrice := _Gen21,
+            origin := _Gen22,
+            blockhashes := _Gen23,
+            block := _Gen24 },
+          network := {
+            chainID := _Gen30,
+            accounts := { val := _Val9 },
+            txOrder := _Gen31,
+            txPending := _Gen32,
+            messages := _Gen33,
+            withdrawalsPending := _Gen34,
+            withdrawalsOrder := _Gen35,
+            withdrawals := _Gen36 } } },
+      generatedCounter := _DotVar0 }
+
+def sloadRHS
+  {_Val22 : SortMap}
+  {ID_CELL _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {_Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  {_Val17 _Val19 _Val20 _Val21 : SortSet}
+  {_Val18 : SortKItem} : SortGeneratedTopCell :=
+  { kevm := {
+      k := { val := K_CELL },
+      exitCode := _Gen37,
+      mode := _Gen38,
+      schedule := { val := SCHEDULE_CELL },
+      useGas := { val := true },
+      ethereum := {
+        evm := {
+          output := _Gen15,
+          statusCode := _Gen16,
+          callStack := _Gen17,
+          interimStates := _Gen18,
+          touchedAccounts := _Gen19,
+          callState := {
+            program := _Gen0,
+            jumpDests := _Gen1,
+            id := { val := (@inj SortInt SortAccount) ID_CELL },
+            caller := _Gen2,
+            callData := _Gen3,
+            callValue := _Gen4,
+            wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» _Val10 WS },
+            localMem := _Gen5,
+            pc := { val := _Val11 },
+            gas := { val := (@inj SortInt SortGas) _Val16 },
+            memoryUsed := _Gen6,
+            callGas := _Gen7,
+            static := _Gen8,
+            callDepth := _Gen9 },
+          versionedHashes := _Gen20,
+          substate := {
+            selfDestruct := _Gen10,
+            log := _Gen11,
+            refund := _Gen12,
+            accessedAccounts := _Gen13,
+            accessedStorage := { val := _Val22 },
+            createdAccounts := _Gen14 },
+          gasPrice := _Gen21,
+          origin := _Gen22,
+          blockhashes := _Gen23,
+          block := _Gen24 },
+        network := {
+          chainID := _Gen30,
+          accounts := { val := _Val24 },
+          txOrder := _Gen31,
+          txPending := _Gen32,
+          messages := _Gen33,
+          withdrawalsPending := _Gen34,
+          withdrawalsOrder := _Gen35,
+          withdrawals := _Gen36 } } },
+      generatedCounter := _DotVar0 }
+
+theorem rw_sloadLHS_sloadRHS
+  {ACCESSEDSTORAGE_CELL STORAGE_CELL _Val22 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  {_Val17 _Val19 _Val20 _Val21 : SortSet}
+  {_Val18 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val1)
+  (defn_Val2 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val2)
+  (defn_Val3 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val3)
+  (defn_Val4 : kite _Val1 _Val2 _Val3 = some _Val4)
+  (defn_Val5 : «_<=Int_» _Val4 GAS_CELL = some _Val5)
+  (defn_Val6 : _andBool_ _Val0 _Val5 = some _Val6)
+  (defn_Val7 : _andBool_ USEGAS_CELL _Val6 = some _Val7)
+  (defn_Val8 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val8)
+  (defn_Val9 : _AccountCellMap_ _Val8 _DotVar6 = some _Val9)
+  (defn_Val10 : lookup STORAGE_CELL W0 = some _Val10)
+  (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
+  (defn_Val12 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val14)
+  (defn_Val15 : kite _Val12 _Val13 _Val14 = some _Val15)
+  (defn_Val16 : «_-Int_» GAS_CELL _Val15 = some _Val16)
+  (defn_Val17 : «.Set» = some _Val17)
+  (defn_Val18 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val17) = some _Val18)
+  (defn_Val19 : «project:Set» (SortK.kseq _Val18 SortK.dotk) = some _Val19)
+  (defn_Val20 : SetItem ((@inj SortInt SortKItem) W0) = some _Val20)
+  (defn_Val21 : «_|Set__SET_Set_Set_Set» _Val19 _Val20 = some _Val21)
+  (defn_Val22 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val21) = some _Val22)
+  (defn_Val23 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val23)
+  (defn_Val24 : _AccountCellMap_ _Val23 _DotVar6 = some _Val24)
+  (req : _Val7 = true) :
+  Rewrites
+  (@sloadLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL W0 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)
+  (@sloadRHS _Val22 ID_CELL _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 K_CELL SCHEDULE_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 WS _DotVar0 _DotVar6 _Val23 _Val24 _Val8 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val17 _Val19 _Val20 _Val21 _Val18) := by
+  apply (@Rewrites.SLOAD_SUMMARY_SLOAD_SUMMARY_1 ACCESSEDSTORAGE_CELL STORAGE_CELL _Val22 GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 K_CELL SCHEDULE_CELL USEGAS_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 WS _DotVar0 _DotVar6 _Val23 _Val24 _Val8 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val17 _Val19 _Val20 _Val21 _Val18)
+  all_goals assumption
+
+theorem sload_prestate_equiv
+  {ACCESSEDSTORAGE_CELL : SortMap}
+  {GAS_CELL ID_CELL PC_CELL W0 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  (symState : EVM.State):
+  let lhs := @sloadLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL W0 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9
+  stateMap symState lhs =
+  {symState with
+    stack := (intMap W0) :: wordStackMap WS
+    pc := intMap PC_CELL
+    gasAvailable := intMap GAS_CELL
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)
+                  perm := !lhs.isStatic.val},
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap (SortGeneratedTopCell.accessedStorage lhs)
+            refundBalance := intMap lhs.refund.val
+           }
+    returnData := _Gen15.val
+    accountMap := Axioms.SortAccountsCellMap lhs.accounts
+    } := by rfl
+
+theorem sload_poststate_equiv
+  -- We have to include `ACCESSEDSTORAGE_CELL` as we need the original map to look up
+  {ACCESSEDSTORAGE_CELL _Val22 : SortMap}
+  -- We have to include `W0` as we need the key to look up
+  {GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {_Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  {_Val17 _Val19 _Val20 _Val21 : SortSet}
+  {_Val18 : SortKItem}
+  (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
+  (defn_Val12 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val14)
+  (defn_Val15 : kite _Val12 _Val13 _Val14 = some _Val15)
+  (defn_Val16 : «_-Int_» GAS_CELL _Val15 = some _Val16)
+  (gasEnough : _Val15 ≤ GAS_CELL)
+  (gasSmall : GAS_CELL < ↑UInt256.size)
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (symState : EVM.State) :
+  let rhs := @sloadRHS _Val22 ID_CELL _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 K_CELL SCHEDULE_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 WS _DotVar0 _DotVar6 _Val23 _Val24 _Val8 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val17 _Val19 _Val20 _Val21 _Val18
+  stateMap symState rhs =
+  {symState with
+    stack := intMap _Val10 :: wordStackMap WS
+    pc := intMap («_+Int'_» PC_CELL 1)
+    gasAvailable := intMap GAS_CELL -  intMap _Val15 --(sload_gas ACCESSEDSTORAGE_CELL W0)
+    executionEnv := {symState.executionEnv with
+                  code := _Gen0.val,
+                  codeOwner := accountAddressMap ((@inj SortInt SortAccount) ID_CELL)
+                  perm := !rhs.isStatic.val},
+    accountMap := Axioms.SortAccountsCellMap rhs.accounts
+    substate := {symState.substate with
+            accessedStorageKeys :=  Axioms.SortAccessedStorageCellMap  rhs.accessedStorage
+            refundBalance := intMap _Gen12.val
+           }
+    returnData := _Gen15.val
+  } := by
+  simp_all [sloadRHS, stateMap, «_-Int_», plusInt_def, «_+Int_»]
+  aesop (add simp [inj, Inj.inj]) (add safe (by rw [intMap_sub_dist]))
+
+theorem step_sload_equiv
+  {ACCESSEDSTORAGE_CELL STORAGE_CELL _Val22 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  {_Val17 _Val19 _Val20 _Val21 : SortSet}
+  {_Val18 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val1)
+  (defn_Val2 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val2)
+  (defn_Val3 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val3)
+  (defn_Val4 : kite _Val1 _Val2 _Val3 = some _Val4)
+  (defn_Val5 : «_<=Int_» _Val4 GAS_CELL = some _Val5)
+  /- (defn_Val6 : _andBool_ _Val0 _Val5 = some _Val6) -/
+  (defn_Val7 : _andBool_ USEGAS_CELL _Val6 = some _Val7)
+  (defn_Val8 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val8)
+  (defn_Val9 : _AccountCellMap_ _Val8 _DotVar6 = some _Val9)
+  (defn_Val10 : lookup STORAGE_CELL W0 = some _Val10)
+  (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
+  (defn_Val12 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val14)
+  (defn_Val15 : kite _Val12 _Val13 _Val14 = some _Val15)
+  (defn_Val16 : «_-Int_» GAS_CELL _Val15 = some _Val16)
+  (defn_Val17 : «.Set» = some _Val17)
+  (defn_Val18 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val17) = some _Val18)
+  (defn_Val19 : «project:Set» (SortK.kseq _Val18 SortK.dotk) = some _Val19)
+  (defn_Val20 : SetItem ((@inj SortInt SortKItem) W0) = some _Val20)
+  (defn_Val21 : «_|Set__SET_Set_Set_Set» _Val19 _Val20 = some _Val21)
+  (defn_Val22 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val21) = some _Val22)
+  (defn_Val23 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val23)
+  (defn_Val24 : _AccountCellMap_ _Val23 _DotVar6 = some _Val24)
+  (req : _Val7 = true)
+  (symState : EVM.State)
+  -- needed for EVM.step
+  (gasCost : ℕ)
+  -- Necessary assumptions for equivalence
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (gavailEnough : _Val15 ≤ GAS_CELL)
+  (gavailSmall : GAS_CELL < ↑UInt256.size)
+  (gasCostValue : gasCost = _Val15.toNat)
+  (pcountSmall : PC_CELL + 1 < UInt256.size)
+  (pcountNonneg : 0 ≤ PC_CELL):
+  EVM.step_sload (Int.toNat GAS_CELL) gasCost (stateMap symState (@sloadLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL W0 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
+  .ok (stateMap {symState with execLength := symState.execLength + 1} (@sloadRHS _Val22 ID_CELL _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 K_CELL SCHEDULE_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 WS _DotVar0 _DotVar6 _Val23 _Val24 _Val8 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val17 _Val19 _Val20 _Val21 _Val18)) := by
+  cases cg: (Int.toNat GAS_CELL)
+  next =>
+    have val15_pos : 0 < _Val15 := by simp at defn_Val15; aesop
+    have _ := Int.lt_of_lt_of_le val15_pos gavailEnough
+    omega
+  rw [sload_prestate_equiv, EVM.step_sload_summary] <;> try assumption
+  rw [sloadLHS, sload_poststate_equiv, sloadRHS] <;> try congr
+  . simp[State.lookupAccount, SortGeneratedTopCell.accounts, accountAddressMap, inj_ID_CELL]
+    aesop
+  . simp
+    apply (Axioms.accessedStorageCell_map_insert defn_Val17 defn_Val18 defn_Val19 defn_Val20 defn_Val21 defn_Val22)
+  . simp at defn_Val4; aesop (add simp [intMap])
+  . rw [plusInt_def, ←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
+  . simp [State.lookupAccount]
+    cases origc: _Gen27; next orig_storage =>
+    rw [@Axioms.findAccountInAccountCellMap ID_CELL _Gen25 _Gen26 STORAGE_CELL orig_storage _Gen28 _Gen29 _Val8 _DotVar6 _Val9]
+     <;> congr
+    . simp [Account.lookupStorage]; apply Axioms.lookup_mapped_storage; assumption
+    . rw [←origc]; assumption
+  . omega
+
+theorem X_sload_equiv
+  {ACCESSEDSTORAGE_CELL STORAGE_CELL _Val22 : SortMap}
+  {GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+  {K_CELL : SortK}
+  {SCHEDULE_CELL : SortSchedule}
+  {USEGAS_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+  {WS : SortWordStack}
+  {_DotVar0 : SortGeneratedCounterCell}
+  {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+  {_Gen0 : SortProgramCell}
+  {_Gen1 : SortJumpDestsCell}
+  {_Gen10 : SortSelfDestructCell}
+  {_Gen11 : SortLogCell}
+  {_Gen12 : SortRefundCell}
+  {_Gen13 : SortAccessedAccountsCell}
+  {_Gen14 : SortCreatedAccountsCell}
+  {_Gen15 : SortOutputCell}
+  {_Gen16 : SortStatusCodeCell}
+  {_Gen17 : SortCallStackCell}
+  {_Gen18 : SortInterimStatesCell}
+  {_Gen19 : SortTouchedAccountsCell}
+  {_Gen2 : SortCallerCell}
+  {_Gen20 : SortVersionedHashesCell}
+  {_Gen21 : SortGasPriceCell}
+  {_Gen22 : SortOriginCell}
+  {_Gen23 : SortBlockhashesCell}
+  {_Gen24 : SortBlockCell}
+  {_Gen25 : SortBalanceCell}
+  {_Gen26 : SortCodeCell}
+  {_Gen27 : SortOrigStorageCell}
+  {_Gen28 : SortTransientStorageCell}
+  {_Gen29 : SortNonceCell}
+  {_Gen3 : SortCallDataCell}
+  {_Gen30 : SortChainIDCell}
+  {_Gen31 : SortTxOrderCell}
+  {_Gen32 : SortTxPendingCell}
+  {_Gen33 : SortMessagesCell}
+  {_Gen34 : SortWithdrawalsPendingCell}
+  {_Gen35 : SortWithdrawalsOrderCell}
+  {_Gen36 : SortWithdrawalsCell}
+  {_Gen37 : SortExitCodeCell}
+  {_Gen38 : SortModeCell}
+  {_Gen4 : SortCallValueCell}
+  {_Gen5 : SortLocalMemCell}
+  {_Gen6 : SortMemoryUsedCell}
+  {_Gen7 : SortCallGasCell}
+  {_Gen8 : SortStaticCell}
+  {_Gen9 : SortCallDepthCell}
+  {_Val17 _Val19 _Val20 _Val21 : SortSet}
+  {_Val18 : SortKItem}
+  (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+  (defn_Val1 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val1)
+  (defn_Val2 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val2)
+  (defn_Val3 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val3)
+  (defn_Val4 : kite _Val1 _Val2 _Val3 = some _Val4)
+  (defn_Val5 : «_<=Int_» _Val4 GAS_CELL = some _Val5)
+  /- (defn_Val6 : _andBool_ _Val0 _Val5 = some _Val6) -/
+  (defn_Val7 : _andBool_ USEGAS_CELL _Val6 = some _Val7)
+  (defn_Val8 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val8)
+  (defn_Val9 : _AccountCellMap_ _Val8 _DotVar6 = some _Val9)
+  (defn_Val10 : lookup STORAGE_CELL W0 = some _Val10)
+  (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
+  (defn_Val12 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val12)
+  (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+  (defn_Val14 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val14)
+  (defn_Val15 : kite _Val12 _Val13 _Val14 = some _Val15)
+  (defn_Val16 : «_-Int_» GAS_CELL _Val15 = some _Val16)
+  (defn_Val17 : «.Set» = some _Val17)
+  (defn_Val18 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val17) = some _Val18)
+  (defn_Val19 : «project:Set» (SortK.kseq _Val18 SortK.dotk) = some _Val19)
+  (defn_Val20 : SetItem ((@inj SortInt SortKItem) W0) = some _Val20)
+  (defn_Val21 : «_|Set__SET_Set_Set_Set» _Val19 _Val20 = some _Val21)
+  (defn_Val22 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val21) = some _Val22)
+  (defn_Val23 : AccountCellMapItem { val := ID_CELL } {
+    acctID := { val := ID_CELL },
+    balance := _Gen25,
+    code := _Gen26,
+    storage := { val := STORAGE_CELL },
+    origStorage := _Gen27,
+    transientStorage := _Gen28,
+    nonce := _Gen29 } = some _Val23)
+  (defn_Val24 : _AccountCellMap_ _Val23 _DotVar6 = some _Val24)
+  (req : _Val7 = true)
+  (symState : EVM.State)
+  -- Necessary assumptions for equivalence
+  (cancun : SCHEDULE_CELL = .CANCUN_EVM)
+  (gavailEnough : _Val15 < GAS_CELL)
+  (gavailSmall : GAS_CELL < ↑UInt256.size)
+  (codeSloadLHS : _Gen0 = ⟨⟨#[(0x54 : UInt8)]⟩⟩)
+  (codeSloadRHS : _Gen26 = ⟨⟨⟨#[(0x54 : UInt8)]⟩⟩⟩)
+  (pcZero : PC_CELL = 0)
+  (wordStackOk : sizeWordStackAux WS 0 < some 1024)
+  :
+  EVM.X false (UInt256.toNat (intMap GAS_CELL)) (stateMap symState (@sloadLHS ACCESSEDSTORAGE_CELL GAS_CELL ID_CELL PC_CELL W0 K_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar6 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9)) =
+  .ok (.success (stateMap {symState with execLength := symState.execLength + 2} (@sloadRHS _Val22 ID_CELL _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 K_CELL SCHEDULE_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 WS _DotVar0 _DotVar6 _Val23 _Val24 _Val8 _Val9 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 ⟨.empty⟩ _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen22 _Gen23 _Gen24 _Gen25 _Gen26 _Gen27 _Gen28 _Gen29 _Gen3 _Gen30 _Gen31 _Gen32 _Gen33 _Gen34 _Gen35 _Gen36 _Gen37 _Gen38 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _Val17 _Val19 _Val20 _Val21 _Val18)) .empty ) := by
+  rw [pcZero, codeSloadLHS, codeSloadRHS, sload_prestate_equiv, sload_poststate_equiv]
+  <;> first | assumption | try linarith
+  simp
+  have pc_equiv : intMap 0 = UInt256.ofNat 0 := rfl
+  rw [pc_equiv, X_sload_summary] <;> try simp [State.lookupAccount, sloadLHS, sloadRHS]
+  <;> try assumption
+  . constructor <;> constructor
+    . rw [Axioms.accessedStorageCell_map_insert defn_Val17 defn_Val18 defn_Val19 defn_Val20 defn_Val21 defn_Val22]
+      aesop
+    . simp [EVM.Csload, GasConstants.Gwarmaccess, GasConstants.Gcoldsload]
+      simp [*] at defn_Val12 defn_Val13 defn_Val14 defn_Val15; congr
+      simp [←defn_Val13, ←defn_Val14, ←defn_Val15]
+      rw [Axioms.contains_accessedStorage_map defn_Val12]
+      aesop
+    . aesop
+    . cases origc: _Gen27; next orig_storage =>
+      rw [@Axioms.findAccountInAccountCellMap ID_CELL _Gen25 _Gen26 STORAGE_CELL orig_storage _Gen28 _Gen29 _Val8 _DotVar6 _Val9]
+      <;> congr
+      . simp [Account.lookupStorage]; apply Axioms.lookup_mapped_storage; assumption
+      . rw [←origc]; assumption
+  . simp_all [sizeWordStack_def]
+    simp [LT.lt, Option.lt, OfNat.ofNat, (@Int.ofNat_eq_coe 1024)] at wordStackOk
+    exact (Int.lt_of_ofNat_lt_ofNat wordStackOk)
+  . simp [EVM.Csload, GasConstants.Gwarmaccess, GasConstants.Gcoldsload]
+    rw [Axioms.contains_accessedStorage_map defn_Val12]
+    simp [cancun] at *; rw [intMap_toNat] <;> aesop (add safe (by linarith))
+
+end SloadOpcodeEquivalence

--- a/EvmEquivalence/KEVM2Lean/Func.lean
+++ b/EvmEquivalence/KEVM2Lean/Func.lean
@@ -1,156 +1,140 @@
 import EvmEquivalence.KEVM2Lean.Inj
 import EvmEquivalence.KEVM2Lean.ScheduleOrdering
 
+def SCHEDULE_GhasstaticcallDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _53fc758 : SortBool → Option SortBool
+  | true => some false
+  | _ => none
+
 def _17ebc68 : SortBool → Option SortBool
   | false => some true
   | _ => none
 
-axiom _modInt_ (x0 : SortInt) (x1 : SortInt) : Option SortInt
+axiom «_in_keys(_)_MAP_Bool_KItem_Map» (x0 : SortKItem) (x1 : SortMap) : Option SortBool
 
-def SCHEDULE_GhighDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ghigh_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
-  | _, _ => none
-
-def SCHEDULE_GmemoryDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
-  | _, _ => none
-
-def SCHEDULE_GhassstorestipendIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
-  | _, _ => none
-
-axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
-
-def SCHEDULE_GhasselfbalanceDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstorePetersburg : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.PETERSBURG_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasrevertDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasrevertByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaswithdrawalsDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GhasblobhashCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
   | _, _ => none
 
 def _991a329 : SortBool → SortBool → Option SortBool
   | false, B => some B
   | _, _ => none
 
-def SCHEDULE_Ghaseip6780Cancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+def SCHEDULE_GhasmaxinitcodesizeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def _7174452 : SortBool → SortBool → Option SortBool
-  | true, _Gen0 => some true
+def SCHEDULE_GhasdirtysstoreDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GhasstaticcallByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+def SCHEDULE_GhasdirtysstoreIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
   | _, _ => none
 
-def SCHEDULE_GhasmcopyCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasshiftConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GzerovaluenewaccountgasDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasrejectedfirstbyteLondon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_Ghascreate2Default : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GstaticcalldepthDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
   | _, _ => none
 
 def SCHEDULE_GhasrejectedfirstbyteDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_Ghascreate2Constantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+def SCHEDULE_GselfdestructnewaccountDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GhasmaxinitcodesizeDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GhasrevertByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
   | _, _ => none
 
-def SCHEDULE_GemptyisnonexistentDragon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GemptyisnonexistentDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GhaspushzeroShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
   | _, _ => none
 
 def SCHEDULE_GhasreturndataDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GhaschainidDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
+axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
 
-def SCHEDULE_GzerovaluenewaccountgasDragon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GselfdestructnewaccountTangerine : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasblobbasefeeCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaschainidIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasprevrandaoMerge : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.MERGE_EVM => some true
+def SCHEDULE_GemptyisnonexistentDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some true
   | _, _ => none
 
 def SCHEDULE_GhaspushzeroDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GhasstaticcallDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GstaticcalldepthTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbasefeeLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasmaxinitcodesizeShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasshiftConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasaccesslistDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaschainidIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_hasaccesslistBerlin : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.BERLIN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaswarmcoinbaseShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasselfbalanceDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhastransientDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobhashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
 def SCHEDULE_GhassstorestipendDefault : SortScheduleFlag → SortSchedule → Option SortBool
@@ -161,523 +145,547 @@ def SCHEDULE_GhasmcopyDefault : SortScheduleFlag → SortSchedule → Option Sor
   | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GhaswarmcoinbaseShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobhashCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasextcodehashDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GstaticcalldepthTangerine : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhaspushzeroShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasaccesslistDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def _53fc758 : SortBool → Option SortBool
-  | true => some false
-  | _ => none
-
-def SCHEDULE_GhasreturndataByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaswithdrawalsShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GselfdestructnewaccountDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhastransientDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasprevrandaoDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhastransientCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasextcodehashConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasbasefeeLondon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasbeaconrootCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
 def SCHEDULE_GhasselfbalanceIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
   | _, _ => none
 
-def SCHEDULE_GhasbeaconrootDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GstaticcalldepthDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_hasaccesslistBerlin : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.BERLIN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasmaxinitcodesizeShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasshiftDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobhashDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_Ghaseip6780Default : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+def SCHEDULE_GhasstaticcallByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
   | _, _ => none
 
 def SCHEDULE_GhasbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
+def SCHEDULE_GhasreturndataByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasprevrandaoMerge : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.MERGE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GselfdestructnewaccountTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def _7174452 : SortBool → SortBool → Option SortBool
+  | true, _Gen0 => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrevertDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasshiftDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Cancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhassstorestipendIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmcopyCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaschainidDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GemptyisnonexistentDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Constantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaswithdrawalsShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstorePetersburg : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.PETERSBURG_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhastransientCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrejectedfirstbyteLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
 def SCHEDULE_GhaswarmcoinbaseDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GhasprevrandaoDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
-def _5b9db8d : SortBool → SortBool → Option SortBool
-  | true, B => some B
-  | _, _ => none
-
-def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
-  | _, _ => none
-
-axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
-
-def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-axiom «.AccountCellMap» : Option SortAccountCellMap
-
-def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
-  | _, _ => none
-
-def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
-  | _, _ => none
-
-def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GbalanceTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 400
-  | _, _ => none
-
-def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
-  | _, _ => none
-
-def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_RbDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000000000000000000
-  | _, _ => none
-
-def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
-  | _, _ => none
-
-def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
-  | _, _ => none
-
-def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
-  | _, _ => none
-
-def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GsloadIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 800
-  | _, _ => none
-
-def SCHEDULE_GtxdatazeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatazero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
-  | _, _ => none
-
-def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
-  | _, _ => none
-
-def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
-  | _, _ => none
-
-def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
-  | _, _ => none
-
-def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
-  | _, _ => none
-
-def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
-  | _, _ => none
-
-def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
-  | _, _ => none
-
-def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
-  | _, _ => none
-
-def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
-  | _, _ => none
-
-def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
+def SCHEDULE_GhaswithdrawalsDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
   | _, _ => none
 
 def SCHEDULE_GextcodesizeDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
   | _, _ => none
 
-def SCHEDULE_GcoldaccountaccessBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2600
+def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
   | _, _ => none
 
-def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+axiom «_==Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
+
+axiom _modInt_ (x0 : SortInt) (x1 : SortInt) : Option SortInt
+
+def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
   | _, _ => none
 
-def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
+axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
 
-def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
-  | _, _ => none
-
-def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
-  | _, _ => none
-
-def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
-  | _, _ => none
-
-def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
-  | _, _ => none
+axiom «_<Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
 
 def _1ff8f4d {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
   | C, B1, _Gen0 => do
     guard C
     return B1
 
-def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+axiom «Set:in» (x0 : SortKItem) (x1 : SortSet) : Option SortBool
+
+def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
   | _, _ => none
 
-def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
   | _, _ => none
 
-def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
-  | _, _ => none
-
-def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
-  | _, _ => none
-
-def SCHEDULE_GexpDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexp_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
-  | _, _ => none
-
-def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
-  | _, _ => none
-
-def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-axiom «_==Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
-
-def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
-  | _, _ => none
-
-def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
-  | _, _ => none
-
-def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
-  | _, _ => none
-
-def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
-  | _, _ => none
-
-def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
-  | _, _ => none
-
-def SCHEDULE_maxCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4294967295
-  | _, _ => none
-
-def SCHEDULE_GfroundDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gfround_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
   | _, _ => none
 
 def SCHEDULE_GquaddivisorBerlin : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 3
   | _, _ => none
 
-def _61fbef3 : SortBool → SortBool → Option SortBool
-  | false, _Gen0 => some false
+def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
   | _, _ => none
 
-def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
   | _, _ => none
 
-def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
+  | _, _ => none
+
+def SCHEDULE_maxCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4294967295
+  | _, _ => none
+
+def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
+  | _, _ => none
+
+def SCHEDULE_GtxdatazeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatazero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4
+  | _, _ => none
+
+def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+  | _, _ => none
+
+def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
+  | _, _ => none
+
+def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
   | _, _ => none
 
 def SCHEDULE_GquaddivisorDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
   | _, _ => none
 
-def SCHEDULE_GlogtopicDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glogtopic_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
   | _, _ => none
 
-def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
   | _, _ => none
 
-def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
+def SCHEDULE_GcoldaccountaccessBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2600
   | _, _ => none
 
-def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
+def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
+  | _, _ => none
+
+def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
+  | _, _ => none
+
+def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
+  | _, _ => none
+
+def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _61fbef3 : SortBool → SortBool → Option SortBool
+  | false, _Gen0 => some false
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GmemoryDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
   | _, _ => none
 
 def SCHEDULE_GtxdatanonzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 68
   | _, _ => none
 
+def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
+  | _, _ => none
+
+def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
+  | _, _ => none
+
+def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
+  | _, _ => none
+
+def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
+  | _, _ => none
+
+def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
+  | _, _ => none
+
+def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+  | _, _ => none
+
+def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
+  | _, _ => none
+
+def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
+  | _, _ => none
+
+def SCHEDULE_GhighDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ghigh_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GlogtopicDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glogtopic_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+  | _, _ => none
+
+def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
+  | _, _ => none
+
+def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
+  | _, _ => none
+
+def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _5b9db8d : SortBool → SortBool → Option SortBool
+  | true, B => some B
+  | _, _ => none
+
+def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
+  | _, _ => none
+
+def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
+  | _, _ => none
+
+def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
+  | _, _ => none
+
+def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
+  | _, _ => none
+
+def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
+  | _, _ => none
+
+def SCHEDULE_GexpDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexp_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_RbDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000000000000000000
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
+  | _, _ => none
+
+def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
+  | _, _ => none
+
+def SCHEDULE_GsloadIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 800
+  | _, _ => none
+
+def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
+  | _, _ => none
+
+def SCHEDULE_GfroundDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gfround_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+  | _, _ => none
+
+def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
+  | _, _ => none
+
+def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GbalanceTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 400
+  | _, _ => none
+
+def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
+  | _, _ => none
+
+def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
+  | _, _ => none
+
 def _a3e3b07 : SortKItem → SortInt → Option SortBool
   | _Gen0, _Gen1 => some false
 
-axiom «_|->_» (x0 : SortKItem) (x1 : SortKItem) : Option SortMap
+axiom «Map:lookup» (x0 : SortMap) (x1 : SortKItem) : Option SortKItem
 
-axiom «Map:lookupOrDefault» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortKItem
+def _105572a : SortK → Option SortBool
+  | K => some false
 
-axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
+def _8d90a32 : SortMap → SortAccount → SortInt → Option SortBool
+  | _Gen0, _Gen1, _Gen2 => some false
 
 def _432e4e6 : SortSet → SortInt → Option SortBool
   | _Gen0, _Gen1 => some false
-
-axiom «Set:in» (x0 : SortKItem) (x1 : SortSet) : Option SortBool
-
-def _75897fa : SortWordStack → SortInt → Option SortInt
-  | SortWordStack.«.WordStack_EVM-TYPES_WordStack», SIZE => some SIZE
-  | _, _ => none
-
-axiom «.Set» : Option SortSet
-
-def _0e7f507 : SortK → Option SortSet
-  | SortK.kseq (SortKItem.inj_SortSet K) SortK.dotk => some K
-  | _ => none
-
-axiom «_in_keys(_)_MAP_Bool_KItem_Map» (x0 : SortKItem) (x1 : SortMap) : Option SortBool
 
 def _92664aa : SortK → Option SortBool
   | SortK.kseq (SortKItem.inj_SortInt Int) SortK.dotk => some true
   | _ => none
 
-def _105572a : SortK → Option SortBool
-  | K => some false
-
-axiom _MessageCellMap_ (x0 : SortMessageCellMap) (x1 : SortMessageCellMap) : Option SortMessageCellMap
+axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
 
 axiom «Set:difference» (x0 : SortSet) (x1 : SortSet) : Option SortSet
 
-axiom «Map:update» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortMap
-
-axiom «_<Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool
-
-axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
-
-axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
-
-def _8d90a32 : SortMap → SortAccount → SortInt → Option SortBool
-  | _Gen0, _Gen1, _Gen2 => some false
-
-axiom «.Map» : Option SortMap
-
-axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
-
-axiom «Map:lookup» (x0 : SortMap) (x1 : SortKItem) : Option SortKItem
-
-axiom «.MessageCellMap» : Option SortMessageCellMap
-
-axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
-
-axiom MessageCellMapItem (x0 : SortMsgIDCell) (x1 : SortMessageCell) : Option SortMessageCellMap
-
-axiom ListItem (x0 : SortKItem) : Option SortList
+def _75897fa : SortWordStack → SortInt → Option SortInt
+  | SortWordStack.«.WordStack_EVM-TYPES_WordStack», SIZE => some SIZE
+  | _, _ => none
 
 axiom «.List» : Option SortList
 
+axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
+
+axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
+
+axiom «.Set» : Option SortSet
+
+axiom «.MessageCellMap» : Option SortMessageCellMap
+
+axiom _MessageCellMap_ (x0 : SortMessageCellMap) (x1 : SortMessageCellMap) : Option SortMessageCellMap
+
+axiom «Map:lookupOrDefault» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortKItem
+
 axiom SetItem (x0 : SortKItem) : Option SortSet
+
+axiom «_|->_» (x0 : SortKItem) (x1 : SortKItem) : Option SortMap
+
+def _0e7f507 : SortK → Option SortSet
+  | SortK.kseq (SortKItem.inj_SortSet K) SortK.dotk => some K
+  | _ => none
+
+axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
+
+axiom MessageCellMapItem (x0 : SortMsgIDCell) (x1 : SortMessageCell) : Option SortMessageCellMap
+
+axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
+
+axiom ListItem (x0 : SortKItem) : Option SortList
+
+axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
 
 axiom WithdrawalCellMapItem (x0 : SortWithdrawalIDCell) (x1 : SortWithdrawalCell) : Option SortWithdrawalCellMap
 
-axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
+axiom «.AccountCellMap» : Option SortAccountCellMap
+
+axiom «Map:update» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortMap
+
+axiom «.Map» : Option SortMap
+
+def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
+
+def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
 
 noncomputable def _85aa67b : SortInt → Option SortInt
   | I => do
     let _Val0 <- _modInt_ I 115792089237316195423570985008687907853269984665640564039457584007913129639936
     return _Val0
 
-def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
+noncomputable def _42ba953 : SortSet → SortInt → Option SortBool
+  | KEYS, KEY => do
+    let _Val0 <- «Set:in» ((@inj SortInt SortKItem) KEY) KEYS
+    guard _Val0
+    return true
 
-def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
+def _andBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_5b9db8d x0 x1) <|> (_61fbef3 x0 x1)
 
 def SCHEDULE_RbByzantium : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.BYZANTIUM_EVM => do
@@ -691,20 +699,13 @@ def SCHEDULE_RbConstantinople : SortScheduleConst → SortSchedule → Option So
     return _Val0
   | _, _ => none
 
-def _andBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_5b9db8d x0 x1) <|> (_61fbef3 x0 x1)
+def isInt (x0 : SortK) : Option SortBool := (_92664aa x0) <|> (_105572a x0)
 
-noncomputable def «EVM_TYPES_#lookup_some» : SortMap → SortInt → Option SortInt
-  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
-    | some ([SortKItem.inj_SortInt VAL], _M) => do
-      let _Val0 <- _modInt_ VAL 115792089237316195423570985008687907853269984665640564039457584007913129639936
-      return _Val0
-    | _ => none
-
-noncomputable def _42ba953 : SortSet → SortInt → Option SortBool
-  | KEYS, KEY => do
-    let _Val0 <- «Set:in» ((@inj SortInt SortKItem) KEY) KEYS
-    guard _Val0
-    return true
+noncomputable def _c384edb : SortSet → SortSet → Option SortSet
+  | S1, S2 => do
+    let _Val0 <- «Set:difference» S2 S1
+    let _Val1 <- _Set_ S1 _Val0
+    return _Val1
 
 mutual
   def _432555e : SortWordStack → SortInt → Option SortInt
@@ -717,17 +718,39 @@ mutual
   def sizeWordStackAux (x0 : SortWordStack) (x1 : SortInt) : Option SortInt := (_432555e x0 x1) <|> (_75897fa x0 x1)
 end
 
+noncomputable def «EVM_TYPES_#lookup_some» : SortMap → SortInt → Option SortInt
+  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
+    | some ([SortKItem.inj_SortInt VAL], _M) => do
+      let _Val0 <- _modInt_ VAL 115792089237316195423570985008687907853269984665640564039457584007913129639936
+      return _Val0
+    | _ => none
+
 def «project:Set» (x0 : SortK) : Option SortSet := _0e7f507 x0
 
-def isInt (x0 : SortK) : Option SortBool := (_92664aa x0) <|> (_105572a x0)
+noncomputable def «EVM_TYPES_#lookup_none» : SortMap → SortInt → Option SortInt
+  | M, KEY => do
+    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortInt SortKItem) KEY) M
+    let _Val1 <- notBool_ _Val0
+    guard _Val1
+    return 0
 
-noncomputable def _c384edb : SortSet → SortSet → Option SortSet
-  | S1, S2 => do
-    let _Val0 <- «Set:difference» S2 S1
-    let _Val1 <- _Set_ S1 _Val0
+noncomputable def _4de6e05 : SortInt → SortInt → Option SortBool
+  | I1, I2 => do
+    let _Val0 <- «_==Int_» I1 I2
+    let _Val1 <- notBool_ _Val0
     return _Val1
 
-noncomputable def chop (x0 : SortInt) : Option SortInt := _85aa67b x0
+noncomputable def _bccaba7 : SortK → SortK → Option SortBool
+  | K1, K2 => do
+    let _Val0 <- «_==K_» K1 K2
+    let _Val1 <- notBool_ _Val0
+    return _Val1
+
+def _2f3f58a {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
+  | C, _Gen0, B2 => do
+    let _Val0 <- notBool_ C
+    guard _Val0
+    return B2
 
 -- Necessary to have the following `mutual` block passing without a `decreasing_by` proof
 attribute [local simp] SortScheduleFlag.toNat SortSchedule.toNat
@@ -899,30 +922,7 @@ mutual
     termination_by sc s => (s.toNat, sc.toNat)
 end
 
-noncomputable def _4de6e05 : SortInt → SortInt → Option SortBool
-  | I1, I2 => do
-    let _Val0 <- «_==Int_» I1 I2
-    let _Val1 <- notBool_ _Val0
-    return _Val1
-
-noncomputable def «EVM_TYPES_#lookup_none» : SortMap → SortInt → Option SortInt
-  | M, KEY => do
-    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortInt SortKItem) KEY) M
-    let _Val1 <- notBool_ _Val0
-    guard _Val1
-    return 0
-
-noncomputable def _bccaba7 : SortK → SortK → Option SortBool
-  | K1, K2 => do
-    let _Val0 <- «_==K_» K1 K2
-    let _Val1 <- notBool_ _Val0
-    return _Val1
-
-def _2f3f58a {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
-  | C, _Gen0, B2 => do
-    let _Val0 <- notBool_ C
-    guard _Val0
-    return B2
+noncomputable def chop (x0 : SortInt) : Option SortInt := _85aa67b x0
 
 noncomputable def «#inStorageAux2» (x0 : SortSet) (x1 : SortInt) : Option SortBool := (_42ba953 x0 x1) <|> (_432e4e6 x0 x1)
 
@@ -1168,6 +1168,46 @@ end
 
 noncomputable def «#inStorageAux1» (x0 : SortKItem) (x1 : SortInt) : Option SortBool := (_c44ca69 x0 x1) <|> (_a3e3b07 x0 x1)
 
+noncomputable def GAS_FEES_Csstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- «_==Int_» CURR NEW
+    let _Val2 <- «_=/=Int_» ORIG CURR
+    let _Val3 <- _orBool_ _Val1 _Val2
+    let _Val4 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
+    let _Val5 <- «_==Int_» ORIG 0
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val8 <- kite _Val5 _Val6 _Val7
+    let _Val9 <- kite _Val3 _Val4 _Val8
+    guard _Val0
+    return _Val9
+
+noncomputable def GAS_FEES_Csstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, _ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- notBool_ _Val0
+    let _Val2 <- «_==Int_» CURR 0
+    let _Val3 <- «_=/=Int_» NEW 0
+    let _Val4 <- _andBool_ _Val2 _Val3
+    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- kite _Val4 _Val5 _Val6
+    guard _Val1
+    return _Val7
+
+noncomputable def GAS_FEES_Rsstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, _ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- notBool_ _Val0
+    let _Val2 <- «_=/=Int_» CURR 0
+    let _Val3 <- «_==Int_» NEW 0
+    let _Val4 <- _andBool_ _Val2 _Val3
+    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
+    let _Val6 <- kite _Val4 _Val5 0
+    guard _Val1
+    return _Val6
+
 noncomputable def GAS_FEES_Rsstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
   | SCHED, NEW, CURR, ORIG => do
     let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
@@ -1205,46 +1245,6 @@ noncomputable def GAS_FEES_Rsstore_new : SortSchedule → SortInt → SortInt �
     guard _Val0
     return _Val31
 
-noncomputable def GAS_FEES_Csstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
-  | SCHED, NEW, CURR, ORIG => do
-    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
-    let _Val1 <- «_==Int_» CURR NEW
-    let _Val2 <- «_=/=Int_» ORIG CURR
-    let _Val3 <- _orBool_ _Val1 _Val2
-    let _Val4 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
-    let _Val5 <- «_==Int_» ORIG 0
-    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
-    let _Val7 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
-    let _Val8 <- kite _Val5 _Val6 _Val7
-    let _Val9 <- kite _Val3 _Val4 _Val8
-    guard _Val0
-    return _Val9
-
-noncomputable def GAS_FEES_Rsstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
-  | SCHED, NEW, CURR, _ORIG => do
-    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
-    let _Val1 <- notBool_ _Val0
-    let _Val2 <- «_=/=Int_» CURR 0
-    let _Val3 <- «_==Int_» NEW 0
-    let _Val4 <- _andBool_ _Val2 _Val3
-    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst SCHED
-    let _Val6 <- kite _Val4 _Val5 0
-    guard _Val1
-    return _Val6
-
-noncomputable def GAS_FEES_Csstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
-  | SCHED, NEW, CURR, _ORIG => do
-    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
-    let _Val1 <- notBool_ _Val0
-    let _Val2 <- «_==Int_» CURR 0
-    let _Val3 <- «_=/=Int_» NEW 0
-    let _Val4 <- _andBool_ _Val2 _Val3
-    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
-    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
-    let _Val7 <- kite _Val4 _Val5 _Val6
-    guard _Val1
-    return _Val7
-
 noncomputable def _dbb1f9e : SortMap → SortAccount → SortInt → Option SortBool
   | TS, ACCT, KEY => do
     let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortAccount SortKItem) ACCT) TS
@@ -1253,8 +1253,8 @@ noncomputable def _dbb1f9e : SortMap → SortAccount → SortInt → Option Sort
     guard _Val0
     return _Val2
 
-noncomputable def Rsstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Rsstore_new x0 x1 x2 x3) <|> (GAS_FEES_Rsstore_old x0 x1 x2 x3)
-
 noncomputable def Csstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Csstore_new x0 x1 x2 x3) <|> (GAS_FEES_Csstore_old x0 x1 x2 x3)
+
+noncomputable def Rsstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Rsstore_new x0 x1 x2 x3) <|> (GAS_FEES_Rsstore_old x0 x1 x2 x3)
 
 noncomputable def «#inStorage» (x0 : SortMap) (x1 : SortAccount) (x2 : SortInt) : Option SortBool := (_dbb1f9e x0 x1 x2) <|> (_8d90a32 x0 x1 x2)

--- a/EvmEquivalence/KEVM2Lean/Inj.lean
+++ b/EvmEquivalence/KEVM2Lean/Inj.lean
@@ -1,634 +1,9 @@
 import EvmEquivalence.KEVM2Lean.Sorts
 
-instance : Inj SortGeneratedCounterCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedCounterCell
-  retr
-    | SortKItem.inj_SortGeneratedCounterCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCellMap SortKItem where
-  inj := SortKItem.inj_SortAccountCellMap
-  retr
-    | SortKItem.inj_SortAccountCellMap x => some x
-    | _ => none
-
-instance : Inj SortIndexCell SortKItem where
-  inj := SortKItem.inj_SortIndexCell
-  retr
-    | SortKItem.inj_SortIndexCell x => some x
-    | _ => none
-
-instance : Inj SortGasLimitCell SortKItem where
-  inj := SortKItem.inj_SortGasLimitCell
-  retr
-    | SortKItem.inj_SortGasLimitCell x => some x
-    | _ => none
-
-instance : Inj SortTxVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortTxVersionedHashesCell
-  retr
-    | SortKItem.inj_SortTxVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsOrderCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsOrderCell
-  retr
-    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
-    | _ => none
-
-instance : Inj SortBlockNonceCell SortKItem where
-  inj := SortKItem.inj_SortBlockNonceCell
-  retr
-    | SortKItem.inj_SortBlockNonceCell x => some x
-    | _ => none
-
-instance : Inj SortNumberCell SortKItem where
-  inj := SortKItem.inj_SortNumberCell
-  retr
-    | SortKItem.inj_SortNumberCell x => some x
-    | _ => none
-
-instance : Inj SortStateRootCell SortKItem where
-  inj := SortKItem.inj_SortStateRootCell
-  retr
-    | SortKItem.inj_SortStateRootCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleCell SortKItem where
-  inj := SortKItem.inj_SortScheduleCell
-  retr
-    | SortKItem.inj_SortScheduleCell x => some x
-    | _ => none
-
-instance : Inj SortBinStackOp SortKItem where
-  inj := SortKItem.inj_SortBinStackOp
-  retr
-    | SortKItem.inj_SortBinStackOp x => some x
-    | _ => none
-
-instance : Inj SortBlockCell SortKItem where
-  inj := SortKItem.inj_SortBlockCell
-  retr
-    | SortKItem.inj_SortBlockCell x => some x
-    | _ => none
-
-instance : Inj SortStaticCell SortKItem where
-  inj := SortKItem.inj_SortStaticCell
-  retr
-    | SortKItem.inj_SortStaticCell x => some x
-    | _ => none
-
 instance : Inj SortMessageCell SortKItem where
   inj := SortKItem.inj_SortMessageCell
   retr
     | SortKItem.inj_SortMessageCell x => some x
-    | _ => none
-
-instance : Inj SortBool SortKItem where
-  inj := SortKItem.inj_SortBool
-  retr
-    | SortKItem.inj_SortBool x => some x
-    | _ => none
-
-instance : Inj SortMessagesCell SortKItem where
-  inj := SortKItem.inj_SortMessagesCell
-  retr
-    | SortKItem.inj_SortMessagesCell x => some x
-    | _ => none
-
-instance : Inj SortTxMaxFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxFeeCell
-  retr
-    | SortKItem.inj_SortTxMaxFeeCell x => some x
-    | _ => none
-
-instance : Inj SortWordStack SortKItem where
-  inj := SortKItem.inj_SortWordStack
-  retr
-    | SortKItem.inj_SortWordStack x => some x
-    | _ => none
-
-instance : Inj SortToCell SortKItem where
-  inj := SortKItem.inj_SortToCell
-  retr
-    | SortKItem.inj_SortToCell x => some x
-    | _ => none
-
-instance : Inj SortIdCell SortKItem where
-  inj := SortKItem.inj_SortIdCell
-  retr
-    | SortKItem.inj_SortIdCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsCell
-  retr
-    | SortKItem.inj_SortWithdrawalsCell x => some x
-    | _ => none
-
-instance : Inj SortExtraDataCell SortKItem where
-  inj := SortKItem.inj_SortExtraDataCell
-  retr
-    | SortKItem.inj_SortExtraDataCell x => some x
-    | _ => none
-
-instance : Inj SortJSONKey SortKItem where
-  inj
-    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
-  retr
-    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
-    | SortKItem.inj_SortJSONKey x => some x
-    | _ => none
-
-instance : Inj SortTxAccessCell SortKItem where
-  inj := SortKItem.inj_SortTxAccessCell
-  retr
-    | SortKItem.inj_SortTxAccessCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalIDCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalIDCell
-  retr
-    | SortKItem.inj_SortWithdrawalIDCell x => some x
-    | _ => none
-
-instance : Inj SortBaseFeeCell SortKItem where
-  inj := SortKItem.inj_SortBaseFeeCell
-  retr
-    | SortKItem.inj_SortBaseFeeCell x => some x
-    | _ => none
-
-instance : Inj SortCodeCell SortKItem where
-  inj := SortKItem.inj_SortCodeCell
-  retr
-    | SortKItem.inj_SortCodeCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsRootCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsRootCell
-  retr
-    | SortKItem.inj_SortWithdrawalsRootCell x => some x
-    | _ => none
-
-instance : Inj SortCreatedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortCreatedAccountsCell
-  retr
-    | SortKItem.inj_SortCreatedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleConst SortKItem where
-  inj := SortKItem.inj_SortScheduleConst
-  retr
-    | SortKItem.inj_SortScheduleConst x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsPendingCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsPendingCell
-  retr
-    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
-    | _ => none
-
-instance : Inj SortKCell SortKItem where
-  inj := SortKItem.inj_SortKCell
-  retr
-    | SortKItem.inj_SortKCell x => some x
-    | _ => none
-
-instance : Inj SortPcCell SortKItem where
-  inj := SortKItem.inj_SortPcCell
-  retr
-    | SortKItem.inj_SortPcCell x => some x
-    | _ => none
-
-instance : Inj SortAcctIDCell SortKItem where
-  inj := SortKItem.inj_SortAcctIDCell
-  retr
-    | SortKItem.inj_SortAcctIDCell x => some x
-    | _ => none
-
-instance : Inj SortGasPriceCell SortKItem where
-  inj := SortKItem.inj_SortGasPriceCell
-  retr
-    | SortKItem.inj_SortGasPriceCell x => some x
-    | _ => none
-
-instance : Inj SortMsgIDCell SortKItem where
-  inj := SortKItem.inj_SortMsgIDCell
-  retr
-    | SortKItem.inj_SortMsgIDCell x => some x
-    | _ => none
-
-instance : Inj SortSubstateCell SortKItem where
-  inj := SortKItem.inj_SortSubstateCell
-  retr
-    | SortKItem.inj_SortSubstateCell x => some x
-    | _ => none
-
-instance : Inj SortMaybeOpCode SortKItem where
-  inj
-    | SortMaybeOpCode.inj_SortBinStackOp x => SortKItem.inj_SortBinStackOp x
-    | SortMaybeOpCode.inj_SortInternalOp x => SortKItem.inj_SortInternalOp x
-    | SortMaybeOpCode.inj_SortPushOp x => SortKItem.inj_SortPushOp x
-  retr
-    | SortKItem.inj_SortBinStackOp x => some (SortMaybeOpCode.inj_SortBinStackOp x)
-    | SortKItem.inj_SortInternalOp x => some (SortMaybeOpCode.inj_SortInternalOp x)
-    | SortKItem.inj_SortPushOp x => some (SortMaybeOpCode.inj_SortPushOp x)
-    | SortKItem.inj_SortMaybeOpCode x => some x
-    | _ => none
-
-instance : Inj SortCallGasCell SortKItem where
-  inj := SortKItem.inj_SortCallGasCell
-  retr
-    | SortKItem.inj_SortCallGasCell x => some x
-    | _ => none
-
-instance : Inj SortReceiptsRootCell SortKItem where
-  inj := SortKItem.inj_SortReceiptsRootCell
-  retr
-    | SortKItem.inj_SortReceiptsRootCell x => some x
-    | _ => none
-
-instance : Inj SortBlockhashesCell SortKItem where
-  inj := SortKItem.inj_SortBlockhashesCell
-  retr
-    | SortKItem.inj_SortBlockhashesCell x => some x
-    | _ => none
-
-instance : Inj SortLogsBloomCell SortKItem where
-  inj := SortKItem.inj_SortLogsBloomCell
-  retr
-    | SortKItem.inj_SortLogsBloomCell x => some x
-    | _ => none
-
-instance : Inj SortAccountsCell SortKItem where
-  inj := SortKItem.inj_SortAccountsCell
-  retr
-    | SortKItem.inj_SortAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortAccount SortKItem where
-  inj
-    | SortAccount.inj_SortInt x => SortKItem.inj_SortInt x
-    | x => SortKItem.inj_SortAccount x
-  retr
-    | SortKItem.inj_SortInt x => some (SortAccount.inj_SortInt x)
-    | SortKItem.inj_SortAccount x => some x
-    | _ => none
-
-instance : Inj SortAccessedStorageCell SortKItem where
-  inj := SortKItem.inj_SortAccessedStorageCell
-  retr
-    | SortKItem.inj_SortAccessedStorageCell x => some x
-    | _ => none
-
-instance : Inj SortInternalOp SortKItem where
-  inj := SortKItem.inj_SortInternalOp
-  retr
-    | SortKItem.inj_SortInternalOp x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalCell
-  retr
-    | SortKItem.inj_SortWithdrawalCell x => some x
-    | _ => none
-
-instance : Inj SortKevmCell SortKItem where
-  inj := SortKItem.inj_SortKevmCell
-  retr
-    | SortKItem.inj_SortKevmCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleFlag SortKItem where
-  inj := SortKItem.inj_SortScheduleFlag
-  retr
-    | SortKItem.inj_SortScheduleFlag x => some x
-    | _ => none
-
-instance : Inj SortUseGasCell SortKItem where
-  inj := SortKItem.inj_SortUseGasCell
-  retr
-    | SortKItem.inj_SortUseGasCell x => some x
-    | _ => none
-
-instance : Inj SortTxGasPriceCell SortKItem where
-  inj := SortKItem.inj_SortTxGasPriceCell
-  retr
-    | SortKItem.inj_SortTxGasPriceCell x => some x
-    | _ => none
-
-instance : Inj SortTransientStorageCell SortKItem where
-  inj := SortKItem.inj_SortTransientStorageCell
-  retr
-    | SortKItem.inj_SortTransientStorageCell x => some x
-    | _ => none
-
-instance : Inj SortNetworkCell SortKItem where
-  inj := SortKItem.inj_SortNetworkCell
-  retr
-    | SortKItem.inj_SortNetworkCell x => some x
-    | _ => none
-
-instance : Inj SortProgramCell SortKItem where
-  inj := SortKItem.inj_SortProgramCell
-  retr
-    | SortKItem.inj_SortProgramCell x => some x
-    | _ => none
-
-instance : Inj SortLogCell SortKItem where
-  inj := SortKItem.inj_SortLogCell
-  retr
-    | SortKItem.inj_SortLogCell x => some x
-    | _ => none
-
-instance : Inj SortMode SortKItem where
-  inj := SortKItem.inj_SortMode
-  retr
-    | SortKItem.inj_SortMode x => some x
-    | _ => none
-
-instance : Inj SortVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortVersionedHashesCell
-  retr
-    | SortKItem.inj_SortVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortTransactionsRootCell SortKItem where
-  inj := SortKItem.inj_SortTransactionsRootCell
-  retr
-    | SortKItem.inj_SortTransactionsRootCell x => some x
-    | _ => none
-
-instance : Inj SortStorageCell SortKItem where
-  inj := SortKItem.inj_SortStorageCell
-  retr
-    | SortKItem.inj_SortStorageCell x => some x
-    | _ => none
-
-instance : Inj SortTimestampCell SortKItem where
-  inj := SortKItem.inj_SortTimestampCell
-  retr
-    | SortKItem.inj_SortTimestampCell x => some x
-    | _ => none
-
-instance : Inj SortEvmCell SortKItem where
-  inj := SortKItem.inj_SortEvmCell
-  retr
-    | SortKItem.inj_SortEvmCell x => some x
-    | _ => none
-
-instance : Inj SortTxPendingCell SortKItem where
-  inj := SortKItem.inj_SortTxPendingCell
-  retr
-    | SortKItem.inj_SortTxPendingCell x => some x
-    | _ => none
-
-instance : Inj SortBeaconRootCell SortKItem where
-  inj := SortKItem.inj_SortBeaconRootCell
-  retr
-    | SortKItem.inj_SortBeaconRootCell x => some x
-    | _ => none
-
-instance : Inj SortMixHashCell SortKItem where
-  inj := SortKItem.inj_SortMixHashCell
-  retr
-    | SortKItem.inj_SortMixHashCell x => some x
-    | _ => none
-
-instance : Inj SortDifficultyCell SortKItem where
-  inj := SortKItem.inj_SortDifficultyCell
-  retr
-    | SortKItem.inj_SortDifficultyCell x => some x
-    | _ => none
-
-instance : Inj SortGasCell SortKItem where
-  inj := SortKItem.inj_SortGasCell
-  retr
-    | SortKItem.inj_SortGasCell x => some x
-    | _ => none
-
-instance : Inj SortMemoryUsedCell SortKItem where
-  inj := SortKItem.inj_SortMemoryUsedCell
-  retr
-    | SortKItem.inj_SortMemoryUsedCell x => some x
-    | _ => none
-
-instance : Inj SortTxNonceCell SortKItem where
-  inj := SortKItem.inj_SortTxNonceCell
-  retr
-    | SortKItem.inj_SortTxNonceCell x => some x
-    | _ => none
-
-instance : Inj SortWordStackCell SortKItem where
-  inj := SortKItem.inj_SortWordStackCell
-  retr
-    | SortKItem.inj_SortWordStackCell x => some x
-    | _ => none
-
-instance : Inj SortOrigStorageCell SortKItem where
-  inj := SortKItem.inj_SortOrigStorageCell
-  retr
-    | SortKItem.inj_SortOrigStorageCell x => some x
-    | _ => none
-
-instance : Inj SortTxChainIDCell SortKItem where
-  inj := SortKItem.inj_SortTxChainIDCell
-  retr
-    | SortKItem.inj_SortTxChainIDCell x => some x
-    | _ => none
-
-instance : Inj SortStatusCodeCell SortKItem where
-  inj := SortKItem.inj_SortStatusCodeCell
-  retr
-    | SortKItem.inj_SortStatusCodeCell x => some x
-    | _ => none
-
-instance : Inj SortTxOrderCell SortKItem where
-  inj := SortKItem.inj_SortTxOrderCell
-  retr
-    | SortKItem.inj_SortTxOrderCell x => some x
-    | _ => none
-
-instance : Inj SortCallStateCell SortKItem where
-  inj := SortKItem.inj_SortCallStateCell
-  retr
-    | SortKItem.inj_SortCallStateCell x => some x
-    | _ => none
-
-instance : Inj SortEthereumCell SortKItem where
-  inj := SortKItem.inj_SortEthereumCell
-  retr
-    | SortKItem.inj_SortEthereumCell x => some x
-    | _ => none
-
-instance : Inj SortNonceCell SortKItem where
-  inj := SortKItem.inj_SortNonceCell
-  retr
-    | SortKItem.inj_SortNonceCell x => some x
-    | _ => none
-
-instance : Inj SortRefundCell SortKItem where
-  inj := SortKItem.inj_SortRefundCell
-  retr
-    | SortKItem.inj_SortRefundCell x => some x
-    | _ => none
-
-instance : Inj SortAccessedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortAccessedAccountsCell
-  retr
-    | SortKItem.inj_SortAccessedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortMap SortKItem where
-  inj := SortKItem.inj_SortMap
-  retr
-    | SortKItem.inj_SortMap x => some x
-    | _ => none
-
-instance : Inj SortDataCell SortKItem where
-  inj := SortKItem.inj_SortDataCell
-  retr
-    | SortKItem.inj_SortDataCell x => some x
-    | _ => none
-
-instance : Inj SortOriginCell SortKItem where
-  inj := SortKItem.inj_SortOriginCell
-  retr
-    | SortKItem.inj_SortOriginCell x => some x
-    | _ => none
-
-instance : Inj SortSigRCell SortKItem where
-  inj := SortKItem.inj_SortSigRCell
-  retr
-    | SortKItem.inj_SortSigRCell x => some x
-    | _ => none
-
-instance : Inj SortSigSCell SortKItem where
-  inj := SortKItem.inj_SortSigSCell
-  retr
-    | SortKItem.inj_SortSigSCell x => some x
-    | _ => none
-
-instance : Inj SortInterimStatesCell SortKItem where
-  inj := SortKItem.inj_SortInterimStatesCell
-  retr
-    | SortKItem.inj_SortInterimStatesCell x => some x
-    | _ => none
-
-instance : Inj SortStatusCode SortKItem where
-  inj := SortKItem.inj_SortStatusCode
-  retr
-    | SortKItem.inj_SortStatusCode x => some x
-    | _ => none
-
-instance : Inj SortCallStackCell SortKItem where
-  inj := SortKItem.inj_SortCallStackCell
-  retr
-    | SortKItem.inj_SortCallStackCell x => some x
-    | _ => none
-
-instance : Inj SortSchedule SortKItem where
-  inj := SortKItem.inj_SortSchedule
-  retr
-    | SortKItem.inj_SortSchedule x => some x
-    | _ => none
-
-instance : Inj SortPushOp SortKItem where
-  inj := SortKItem.inj_SortPushOp
-  retr
-    | SortKItem.inj_SortPushOp x => some x
-    | _ => none
-
-instance : Inj SortTouchedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortTouchedAccountsCell
-  retr
-    | SortKItem.inj_SortTouchedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortOmmersHashCell SortKItem where
-  inj := SortKItem.inj_SortOmmersHashCell
-  retr
-    | SortKItem.inj_SortOmmersHashCell x => some x
-    | _ => none
-
-instance : Inj SortJSONs SortKItem where
-  inj := SortKItem.inj_SortJSONs
-  retr
-    | SortKItem.inj_SortJSONs x => some x
-    | _ => none
-
-instance : Inj SortSet SortKItem where
-  inj := SortKItem.inj_SortSet
-  retr
-    | SortKItem.inj_SortSet x => some x
-    | _ => none
-
-instance : Inj SortValueCell SortKItem where
-  inj := SortKItem.inj_SortValueCell
-  retr
-    | SortKItem.inj_SortValueCell x => some x
-    | _ => none
-
-instance : Inj SortModeCell SortKItem where
-  inj := SortKItem.inj_SortModeCell
-  retr
-    | SortKItem.inj_SortModeCell x => some x
-    | _ => none
-
-instance : Inj SortTxType SortKItem where
-  inj := SortKItem.inj_SortTxType
-  retr
-    | SortKItem.inj_SortTxType x => some x
-    | _ => none
-
-instance : Inj SortChainIDCell SortKItem where
-  inj := SortKItem.inj_SortChainIDCell
-  retr
-    | SortKItem.inj_SortChainIDCell x => some x
-    | _ => none
-
-instance : Inj SortInt SortKItem where
-  inj := SortKItem.inj_SortInt
-  retr
-    | SortKItem.inj_SortInt x => some x
-    | _ => none
-
-instance : Inj SortPreviousHashCell SortKItem where
-  inj := SortKItem.inj_SortPreviousHashCell
-  retr
-    | SortKItem.inj_SortPreviousHashCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCell SortKItem where
-  inj := SortKItem.inj_SortAccountCell
-  retr
-    | SortKItem.inj_SortAccountCell x => some x
-    | _ => none
-
-instance : Inj SortMessageCellMap SortKItem where
-  inj := SortKItem.inj_SortMessageCellMap
-  retr
-    | SortKItem.inj_SortMessageCellMap x => some x
-    | _ => none
-
-instance : Inj SortTxMaxBlobFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxBlobFeeCell
-  retr
-    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCode SortKItem where
-  inj
-    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
-  retr
-    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
-    | SortKItem.inj_SortAccountCode x => some x
-    | _ => none
-
-instance : Inj SortExitCodeCell SortKItem where
-  inj := SortKItem.inj_SortExitCodeCell
-  retr
-    | SortKItem.inj_SortExitCodeCell x => some x
     | _ => none
 
 instance : Inj SortJSON SortKItem where
@@ -650,40 +25,40 @@ instance : Inj SortJSON SortKItem where
     | SortKItem.inj_SortJSON x => some x
     | _ => none
 
-instance : Inj SortBlobGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortBlobGasUsedCell
+instance : Inj SortMap SortKItem where
+  inj := SortKItem.inj_SortMap
   retr
-    | SortKItem.inj_SortBlobGasUsedCell x => some x
+    | SortKItem.inj_SortMap x => some x
     | _ => none
 
-instance : Inj SortTxGasLimitCell SortKItem where
-  inj := SortKItem.inj_SortTxGasLimitCell
+instance : Inj SortWithdrawalIDCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalIDCell
   retr
-    | SortKItem.inj_SortTxGasLimitCell x => some x
+    | SortKItem.inj_SortWithdrawalIDCell x => some x
     | _ => none
 
-instance : Inj SortCallDataCell SortKItem where
-  inj := SortKItem.inj_SortCallDataCell
+instance : Inj SortBytes SortKItem where
+  inj := SortKItem.inj_SortBytes
   retr
-    | SortKItem.inj_SortCallDataCell x => some x
+    | SortKItem.inj_SortBytes x => some x
     | _ => none
 
-instance : Inj SortOmmerBlockHeadersCell SortKItem where
-  inj := SortKItem.inj_SortOmmerBlockHeadersCell
+instance : Inj SortBlockNonceCell SortKItem where
+  inj := SortKItem.inj_SortBlockNonceCell
   retr
-    | SortKItem.inj_SortOmmerBlockHeadersCell x => some x
+    | SortKItem.inj_SortBlockNonceCell x => some x
     | _ => none
 
-instance : Inj SortOutputCell SortKItem where
-  inj := SortKItem.inj_SortOutputCell
+instance : Inj SortTxMaxFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxFeeCell
   retr
-    | SortKItem.inj_SortOutputCell x => some x
+    | SortKItem.inj_SortTxMaxFeeCell x => some x
     | _ => none
 
-instance : Inj SortCallValueCell SortKItem where
-  inj := SortKItem.inj_SortCallValueCell
+instance : Inj SortNumberCell SortKItem where
+  inj := SortKItem.inj_SortNumberCell
   retr
-    | SortKItem.inj_SortCallValueCell x => some x
+    | SortKItem.inj_SortNumberCell x => some x
     | _ => none
 
 instance : Inj SortList SortKItem where
@@ -692,28 +67,10 @@ instance : Inj SortList SortKItem where
     | SortKItem.inj_SortList x => some x
     | _ => none
 
-instance : Inj SortValidatorIndexCell SortKItem where
-  inj := SortKItem.inj_SortValidatorIndexCell
+instance : Inj SortBlockCell SortKItem where
+  inj := SortKItem.inj_SortBlockCell
   retr
-    | SortKItem.inj_SortValidatorIndexCell x => some x
-    | _ => none
-
-instance : Inj SortSelfDestructCell SortKItem where
-  inj := SortKItem.inj_SortSelfDestructCell
-  retr
-    | SortKItem.inj_SortSelfDestructCell x => some x
-    | _ => none
-
-instance : Inj SortJumpDestsCell SortKItem where
-  inj := SortKItem.inj_SortJumpDestsCell
-  retr
-    | SortKItem.inj_SortJumpDestsCell x => some x
-    | _ => none
-
-instance : Inj SortBalanceCell SortKItem where
-  inj := SortKItem.inj_SortBalanceCell
-  retr
-    | SortKItem.inj_SortBalanceCell x => some x
+    | SortKItem.inj_SortBlockCell x => some x
     | _ => none
 
 instance : Inj SortCallDepthCell SortKItem where
@@ -722,10 +79,148 @@ instance : Inj SortCallDepthCell SortKItem where
     | SortKItem.inj_SortCallDepthCell x => some x
     | _ => none
 
-instance : Inj SortAddressCell SortKItem where
-  inj := SortKItem.inj_SortAddressCell
+instance : Inj SortNetworkCell SortKItem where
+  inj := SortKItem.inj_SortNetworkCell
   retr
-    | SortKItem.inj_SortAddressCell x => some x
+    | SortKItem.inj_SortNetworkCell x => some x
+    | _ => none
+
+instance : Inj SortAmountCell SortKItem where
+  inj := SortKItem.inj_SortAmountCell
+  retr
+    | SortKItem.inj_SortAmountCell x => some x
+    | _ => none
+
+instance : Inj SortBaseFeeCell SortKItem where
+  inj := SortKItem.inj_SortBaseFeeCell
+  retr
+    | SortKItem.inj_SortBaseFeeCell x => some x
+    | _ => none
+
+instance : Inj SortWordStack SortKItem where
+  inj := SortKItem.inj_SortWordStack
+  retr
+    | SortKItem.inj_SortWordStack x => some x
+    | _ => none
+
+instance : Inj SortModeCell SortKItem where
+  inj := SortKItem.inj_SortModeCell
+  retr
+    | SortKItem.inj_SortModeCell x => some x
+    | _ => none
+
+instance : Inj SortVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortVersionedHashesCell
+  retr
+    | SortKItem.inj_SortVersionedHashesCell x => some x
+    | _ => none
+
+instance : Inj SortOmmerBlockHeadersCell SortKItem where
+  inj := SortKItem.inj_SortOmmerBlockHeadersCell
+  retr
+    | SortKItem.inj_SortOmmerBlockHeadersCell x => some x
+    | _ => none
+
+instance : Inj SortChainIDCell SortKItem where
+  inj := SortKItem.inj_SortChainIDCell
+  retr
+    | SortKItem.inj_SortChainIDCell x => some x
+    | _ => none
+
+instance : Inj SortKCell SortKItem where
+  inj := SortKItem.inj_SortKCell
+  retr
+    | SortKItem.inj_SortKCell x => some x
+    | _ => none
+
+instance : Inj SortValidatorIndexCell SortKItem where
+  inj := SortKItem.inj_SortValidatorIndexCell
+  retr
+    | SortKItem.inj_SortValidatorIndexCell x => some x
+    | _ => none
+
+instance : Inj SortMode SortKItem where
+  inj := SortKItem.inj_SortMode
+  retr
+    | SortKItem.inj_SortMode x => some x
+    | _ => none
+
+instance : Inj SortAccessedStorageCell SortKItem where
+  inj := SortKItem.inj_SortAccessedStorageCell
+  retr
+    | SortKItem.inj_SortAccessedStorageCell x => some x
+    | _ => none
+
+instance : Inj SortPcCell SortKItem where
+  inj := SortKItem.inj_SortPcCell
+  retr
+    | SortKItem.inj_SortPcCell x => some x
+    | _ => none
+
+instance : Inj SortEthereumCell SortKItem where
+  inj := SortKItem.inj_SortEthereumCell
+  retr
+    | SortKItem.inj_SortEthereumCell x => some x
+    | _ => none
+
+instance : Inj SortStatusCode SortKItem where
+  inj := SortKItem.inj_SortStatusCode
+  retr
+    | SortKItem.inj_SortStatusCode x => some x
+    | _ => none
+
+instance : Inj SortJSONs SortKItem where
+  inj := SortKItem.inj_SortJSONs
+  retr
+    | SortKItem.inj_SortJSONs x => some x
+    | _ => none
+
+instance : Inj SortLogCell SortKItem where
+  inj := SortKItem.inj_SortLogCell
+  retr
+    | SortKItem.inj_SortLogCell x => some x
+    | _ => none
+
+instance : Inj SortJumpDestsCell SortKItem where
+  inj := SortKItem.inj_SortJumpDestsCell
+  retr
+    | SortKItem.inj_SortJumpDestsCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsOrderCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsOrderCell
+  retr
+    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
+    | _ => none
+
+instance : Inj SortReceiptsRootCell SortKItem where
+  inj := SortKItem.inj_SortReceiptsRootCell
+  retr
+    | SortKItem.inj_SortReceiptsRootCell x => some x
+    | _ => none
+
+instance : Inj SortGeneratedCounterCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedCounterCell
+  retr
+    | SortKItem.inj_SortGeneratedCounterCell x => some x
+    | _ => none
+
+instance : Inj SortPushOp SortKItem where
+  inj := SortKItem.inj_SortPushOp
+  retr
+    | SortKItem.inj_SortPushOp x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsCell
+  retr
+    | SortKItem.inj_SortWithdrawalsCell x => some x
+    | _ => none
+
+instance : Inj SortStaticCell SortKItem where
+  inj := SortKItem.inj_SortStaticCell
+  retr
+    | SortKItem.inj_SortStaticCell x => some x
     | _ => none
 
 instance : Inj SortWithdrawalCellMap SortKItem where
@@ -734,16 +229,136 @@ instance : Inj SortWithdrawalCellMap SortKItem where
     | SortKItem.inj_SortWithdrawalCellMap x => some x
     | _ => none
 
-instance : Inj SortCoinbaseCell SortKItem where
-  inj := SortKItem.inj_SortCoinbaseCell
+instance : Inj SortToCell SortKItem where
+  inj := SortKItem.inj_SortToCell
   retr
-    | SortKItem.inj_SortCoinbaseCell x => some x
+    | SortKItem.inj_SortToCell x => some x
+    | _ => none
+
+instance : Inj SortTxOrderCell SortKItem where
+  inj := SortKItem.inj_SortTxOrderCell
+  retr
+    | SortKItem.inj_SortTxOrderCell x => some x
+    | _ => none
+
+instance : Inj SortTransientStorageCell SortKItem where
+  inj := SortKItem.inj_SortTransientStorageCell
+  retr
+    | SortKItem.inj_SortTransientStorageCell x => some x
+    | _ => none
+
+instance : Inj SortExitCodeCell SortKItem where
+  inj := SortKItem.inj_SortExitCodeCell
+  retr
+    | SortKItem.inj_SortExitCodeCell x => some x
+    | _ => none
+
+instance : Inj SortCodeCell SortKItem where
+  inj := SortKItem.inj_SortCodeCell
+  retr
+    | SortKItem.inj_SortCodeCell x => some x
+    | _ => none
+
+instance : Inj SortTxGasPriceCell SortKItem where
+  inj := SortKItem.inj_SortTxGasPriceCell
+  retr
+    | SortKItem.inj_SortTxGasPriceCell x => some x
+    | _ => none
+
+instance : Inj SortMsgIDCell SortKItem where
+  inj := SortKItem.inj_SortMsgIDCell
+  retr
+    | SortKItem.inj_SortMsgIDCell x => some x
+    | _ => none
+
+instance : Inj SortIndexCell SortKItem where
+  inj := SortKItem.inj_SortIndexCell
+  retr
+    | SortKItem.inj_SortIndexCell x => some x
+    | _ => none
+
+instance : Inj SortAcctIDCell SortKItem where
+  inj := SortKItem.inj_SortAcctIDCell
+  retr
+    | SortKItem.inj_SortAcctIDCell x => some x
+    | _ => none
+
+instance : Inj SortOriginCell SortKItem where
+  inj := SortKItem.inj_SortOriginCell
+  retr
+    | SortKItem.inj_SortOriginCell x => some x
+    | _ => none
+
+instance : Inj SortSchedule SortKItem where
+  inj := SortKItem.inj_SortSchedule
+  retr
+    | SortKItem.inj_SortSchedule x => some x
     | _ => none
 
 instance : Inj SortTxTypeCell SortKItem where
   inj := SortKItem.inj_SortTxTypeCell
   retr
     | SortKItem.inj_SortTxTypeCell x => some x
+    | _ => none
+
+instance : Inj SortMessagesCell SortKItem where
+  inj := SortKItem.inj_SortMessagesCell
+  retr
+    | SortKItem.inj_SortMessagesCell x => some x
+    | _ => none
+
+instance : Inj SortGasCell SortKItem where
+  inj := SortKItem.inj_SortGasCell
+  retr
+    | SortKItem.inj_SortGasCell x => some x
+    | _ => none
+
+instance : Inj SortEvmCell SortKItem where
+  inj := SortKItem.inj_SortEvmCell
+  retr
+    | SortKItem.inj_SortEvmCell x => some x
+    | _ => none
+
+instance : Inj SortSelfDestructCell SortKItem where
+  inj := SortKItem.inj_SortSelfDestructCell
+  retr
+    | SortKItem.inj_SortSelfDestructCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsPendingCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsPendingCell
+  retr
+    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCell SortKItem where
+  inj := SortKItem.inj_SortAccountCell
+  retr
+    | SortKItem.inj_SortAccountCell x => some x
+    | _ => none
+
+instance : Inj SortIdCell SortKItem where
+  inj := SortKItem.inj_SortIdCell
+  retr
+    | SortKItem.inj_SortIdCell x => some x
+    | _ => none
+
+instance : Inj SortDataCell SortKItem where
+  inj := SortKItem.inj_SortDataCell
+  retr
+    | SortKItem.inj_SortDataCell x => some x
+    | _ => none
+
+instance : Inj SortTxGasLimitCell SortKItem where
+  inj := SortKItem.inj_SortTxGasLimitCell
+  retr
+    | SortKItem.inj_SortTxGasLimitCell x => some x
+    | _ => none
+
+instance : Inj SortSigSCell SortKItem where
+  inj := SortKItem.inj_SortSigSCell
+  retr
+    | SortKItem.inj_SortSigSCell x => some x
     | _ => none
 
 instance : Inj SortGas SortKItem where
@@ -754,52 +369,52 @@ instance : Inj SortGas SortKItem where
     | SortKItem.inj_SortGas x => some x
     | _ => none
 
-instance : Inj SortSigVCell SortKItem where
-  inj := SortKItem.inj_SortSigVCell
+instance : Inj SortTouchedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortTouchedAccountsCell
   retr
-    | SortKItem.inj_SortSigVCell x => some x
+    | SortKItem.inj_SortTouchedAccountsCell x => some x
     | _ => none
 
-instance : Inj SortBytes SortKItem where
-  inj := SortKItem.inj_SortBytes
+instance : Inj SortExtraDataCell SortKItem where
+  inj := SortKItem.inj_SortExtraDataCell
   retr
-    | SortKItem.inj_SortBytes x => some x
+    | SortKItem.inj_SortExtraDataCell x => some x
     | _ => none
 
-instance : Inj SortGeneratedTopCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedTopCell
+instance : Inj SortNonceCell SortKItem where
+  inj := SortKItem.inj_SortNonceCell
   retr
-    | SortKItem.inj_SortGeneratedTopCell x => some x
+    | SortKItem.inj_SortNonceCell x => some x
     | _ => none
 
-instance : Inj SortExcessBlobGasCell SortKItem where
-  inj := SortKItem.inj_SortExcessBlobGasCell
+instance : Inj SortStorageCell SortKItem where
+  inj := SortKItem.inj_SortStorageCell
   retr
-    | SortKItem.inj_SortExcessBlobGasCell x => some x
+    | SortKItem.inj_SortStorageCell x => some x
     | _ => none
 
-instance : Inj SortTxPriorityFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxPriorityFeeCell
+instance : Inj SortScheduleConst SortKItem where
+  inj := SortKItem.inj_SortScheduleConst
   retr
-    | SortKItem.inj_SortTxPriorityFeeCell x => some x
+    | SortKItem.inj_SortScheduleConst x => some x
     | _ => none
 
-instance : Inj SortAmountCell SortKItem where
-  inj := SortKItem.inj_SortAmountCell
+instance : Inj SortGasPriceCell SortKItem where
+  inj := SortKItem.inj_SortGasPriceCell
   retr
-    | SortKItem.inj_SortAmountCell x => some x
+    | SortKItem.inj_SortGasPriceCell x => some x
     | _ => none
 
-instance : Inj SortGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortGasUsedCell
+instance : Inj SortTxMaxBlobFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxBlobFeeCell
   retr
-    | SortKItem.inj_SortGasUsedCell x => some x
+    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
     | _ => none
 
-instance : Inj SortCallerCell SortKItem where
-  inj := SortKItem.inj_SortCallerCell
+instance : Inj SortOmmersHashCell SortKItem where
+  inj := SortKItem.inj_SortOmmersHashCell
   retr
-    | SortKItem.inj_SortCallerCell x => some x
+    | SortKItem.inj_SortOmmersHashCell x => some x
     | _ => none
 
 instance : Inj SortLocalMemCell SortKItem where
@@ -808,15 +423,423 @@ instance : Inj SortLocalMemCell SortKItem where
     | SortKItem.inj_SortLocalMemCell x => some x
     | _ => none
 
+instance : Inj SortOrigStorageCell SortKItem where
+  inj := SortKItem.inj_SortOrigStorageCell
+  retr
+    | SortKItem.inj_SortOrigStorageCell x => some x
+    | _ => none
+
+instance : Inj SortGasLimitCell SortKItem where
+  inj := SortKItem.inj_SortGasLimitCell
+  retr
+    | SortKItem.inj_SortGasLimitCell x => some x
+    | _ => none
+
+instance : Inj SortSigRCell SortKItem where
+  inj := SortKItem.inj_SortSigRCell
+  retr
+    | SortKItem.inj_SortSigRCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsRootCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsRootCell
+  retr
+    | SortKItem.inj_SortWithdrawalsRootCell x => some x
+    | _ => none
+
+instance : Inj SortCreatedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortCreatedAccountsCell
+  retr
+    | SortKItem.inj_SortCreatedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortBeaconRootCell SortKItem where
+  inj := SortKItem.inj_SortBeaconRootCell
+  retr
+    | SortKItem.inj_SortBeaconRootCell x => some x
+    | _ => none
+
+instance : Inj SortCallStackCell SortKItem where
+  inj := SortKItem.inj_SortCallStackCell
+  retr
+    | SortKItem.inj_SortCallStackCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalCell
+  retr
+    | SortKItem.inj_SortWithdrawalCell x => some x
+    | _ => none
+
+instance : Inj SortTxAccessCell SortKItem where
+  inj := SortKItem.inj_SortTxAccessCell
+  retr
+    | SortKItem.inj_SortTxAccessCell x => some x
+    | _ => none
+
+instance : Inj SortUnStackOp SortKItem where
+  inj := SortKItem.inj_SortUnStackOp
+  retr
+    | SortKItem.inj_SortUnStackOp x => some x
+    | _ => none
+
+instance : Inj SortOutputCell SortKItem where
+  inj := SortKItem.inj_SortOutputCell
+  retr
+    | SortKItem.inj_SortOutputCell x => some x
+    | _ => none
+
+instance : Inj SortJSONKey SortKItem where
+  inj
+    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
+  retr
+    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
+    | SortKItem.inj_SortJSONKey x => some x
+    | _ => none
+
+instance : Inj SortBinStackOp SortKItem where
+  inj := SortKItem.inj_SortBinStackOp
+  retr
+    | SortKItem.inj_SortBinStackOp x => some x
+    | _ => none
+
+instance : Inj SortDifficultyCell SortKItem where
+  inj := SortKItem.inj_SortDifficultyCell
+  retr
+    | SortKItem.inj_SortDifficultyCell x => some x
+    | _ => none
+
+instance : Inj SortCallGasCell SortKItem where
+  inj := SortKItem.inj_SortCallGasCell
+  retr
+    | SortKItem.inj_SortCallGasCell x => some x
+    | _ => none
+
+instance : Inj SortAccount SortKItem where
+  inj
+    | SortAccount.inj_SortInt x => SortKItem.inj_SortInt x
+    | x => SortKItem.inj_SortAccount x
+  retr
+    | SortKItem.inj_SortInt x => some (SortAccount.inj_SortInt x)
+    | SortKItem.inj_SortAccount x => some x
+    | _ => none
+
+instance : Inj SortScheduleCell SortKItem where
+  inj := SortKItem.inj_SortScheduleCell
+  retr
+    | SortKItem.inj_SortScheduleCell x => some x
+    | _ => none
+
+instance : Inj SortWordStackCell SortKItem where
+  inj := SortKItem.inj_SortWordStackCell
+  retr
+    | SortKItem.inj_SortWordStackCell x => some x
+    | _ => none
+
+instance : Inj SortTxVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortTxVersionedHashesCell
+  retr
+    | SortKItem.inj_SortTxVersionedHashesCell x => some x
+    | _ => none
+
+instance : Inj SortAddressCell SortKItem where
+  inj := SortKItem.inj_SortAddressCell
+  retr
+    | SortKItem.inj_SortAddressCell x => some x
+    | _ => none
+
+instance : Inj SortStateRootCell SortKItem where
+  inj := SortKItem.inj_SortStateRootCell
+  retr
+    | SortKItem.inj_SortStateRootCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCode SortKItem where
+  inj
+    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
+  retr
+    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
+    | SortKItem.inj_SortAccountCode x => some x
+    | _ => none
+
+instance : Inj SortMixHashCell SortKItem where
+  inj := SortKItem.inj_SortMixHashCell
+  retr
+    | SortKItem.inj_SortMixHashCell x => some x
+    | _ => none
+
+instance : Inj SortAccessedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortAccessedAccountsCell
+  retr
+    | SortKItem.inj_SortAccessedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortLogsBloomCell SortKItem where
+  inj := SortKItem.inj_SortLogsBloomCell
+  retr
+    | SortKItem.inj_SortLogsBloomCell x => some x
+    | _ => none
+
+instance : Inj SortProgramCell SortKItem where
+  inj := SortKItem.inj_SortProgramCell
+  retr
+    | SortKItem.inj_SortProgramCell x => some x
+    | _ => none
+
+instance : Inj SortGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortGasUsedCell
+  retr
+    | SortKItem.inj_SortGasUsedCell x => some x
+    | _ => none
+
+instance : Inj SortBalanceCell SortKItem where
+  inj := SortKItem.inj_SortBalanceCell
+  retr
+    | SortKItem.inj_SortBalanceCell x => some x
+    | _ => none
+
+instance : Inj SortUseGasCell SortKItem where
+  inj := SortKItem.inj_SortUseGasCell
+  retr
+    | SortKItem.inj_SortUseGasCell x => some x
+    | _ => none
+
+instance : Inj SortValueCell SortKItem where
+  inj := SortKItem.inj_SortValueCell
+  retr
+    | SortKItem.inj_SortValueCell x => some x
+    | _ => none
+
+instance : Inj SortTxChainIDCell SortKItem where
+  inj := SortKItem.inj_SortTxChainIDCell
+  retr
+    | SortKItem.inj_SortTxChainIDCell x => some x
+    | _ => none
+
+instance : Inj SortGeneratedTopCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedTopCell
+  retr
+    | SortKItem.inj_SortGeneratedTopCell x => some x
+    | _ => none
+
+instance : Inj SortMessageCellMap SortKItem where
+  inj := SortKItem.inj_SortMessageCellMap
+  retr
+    | SortKItem.inj_SortMessageCellMap x => some x
+    | _ => none
+
+instance : Inj SortExcessBlobGasCell SortKItem where
+  inj := SortKItem.inj_SortExcessBlobGasCell
+  retr
+    | SortKItem.inj_SortExcessBlobGasCell x => some x
+    | _ => none
+
+instance : Inj SortCallValueCell SortKItem where
+  inj := SortKItem.inj_SortCallValueCell
+  retr
+    | SortKItem.inj_SortCallValueCell x => some x
+    | _ => none
+
+instance : Inj SortCoinbaseCell SortKItem where
+  inj := SortKItem.inj_SortCoinbaseCell
+  retr
+    | SortKItem.inj_SortCoinbaseCell x => some x
+    | _ => none
+
+instance : Inj SortInternalOp SortKItem where
+  inj := SortKItem.inj_SortInternalOp
+  retr
+    | SortKItem.inj_SortInternalOp x => some x
+    | _ => none
+
+instance : Inj SortTransactionsRootCell SortKItem where
+  inj := SortKItem.inj_SortTransactionsRootCell
+  retr
+    | SortKItem.inj_SortTransactionsRootCell x => some x
+    | _ => none
+
+instance : Inj SortSigVCell SortKItem where
+  inj := SortKItem.inj_SortSigVCell
+  retr
+    | SortKItem.inj_SortSigVCell x => some x
+    | _ => none
+
+instance : Inj SortInt SortKItem where
+  inj := SortKItem.inj_SortInt
+  retr
+    | SortKItem.inj_SortInt x => some x
+    | _ => none
+
+instance : Inj SortRefundCell SortKItem where
+  inj := SortKItem.inj_SortRefundCell
+  retr
+    | SortKItem.inj_SortRefundCell x => some x
+    | _ => none
+
+instance : Inj SortAccountsCell SortKItem where
+  inj := SortKItem.inj_SortAccountsCell
+  retr
+    | SortKItem.inj_SortAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCellMap SortKItem where
+  inj := SortKItem.inj_SortAccountCellMap
+  retr
+    | SortKItem.inj_SortAccountCellMap x => some x
+    | _ => none
+
+instance : Inj SortPreviousHashCell SortKItem where
+  inj := SortKItem.inj_SortPreviousHashCell
+  retr
+    | SortKItem.inj_SortPreviousHashCell x => some x
+    | _ => none
+
+instance : Inj SortCallStateCell SortKItem where
+  inj := SortKItem.inj_SortCallStateCell
+  retr
+    | SortKItem.inj_SortCallStateCell x => some x
+    | _ => none
+
+instance : Inj SortTimestampCell SortKItem where
+  inj := SortKItem.inj_SortTimestampCell
+  retr
+    | SortKItem.inj_SortTimestampCell x => some x
+    | _ => none
+
+instance : Inj SortBool SortKItem where
+  inj := SortKItem.inj_SortBool
+  retr
+    | SortKItem.inj_SortBool x => some x
+    | _ => none
+
+instance : Inj SortTxPriorityFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxPriorityFeeCell
+  retr
+    | SortKItem.inj_SortTxPriorityFeeCell x => some x
+    | _ => none
+
+instance : Inj SortSubstateCell SortKItem where
+  inj := SortKItem.inj_SortSubstateCell
+  retr
+    | SortKItem.inj_SortSubstateCell x => some x
+    | _ => none
+
+instance : Inj SortKevmCell SortKItem where
+  inj := SortKItem.inj_SortKevmCell
+  retr
+    | SortKItem.inj_SortKevmCell x => some x
+    | _ => none
+
+instance : Inj SortInterimStatesCell SortKItem where
+  inj := SortKItem.inj_SortInterimStatesCell
+  retr
+    | SortKItem.inj_SortInterimStatesCell x => some x
+    | _ => none
+
+instance : Inj SortSet SortKItem where
+  inj := SortKItem.inj_SortSet
+  retr
+    | SortKItem.inj_SortSet x => some x
+    | _ => none
+
+instance : Inj SortMemoryUsedCell SortKItem where
+  inj := SortKItem.inj_SortMemoryUsedCell
+  retr
+    | SortKItem.inj_SortMemoryUsedCell x => some x
+    | _ => none
+
+instance : Inj SortMaybeOpCode SortKItem where
+  inj
+    | SortMaybeOpCode.inj_SortBinStackOp x => SortKItem.inj_SortBinStackOp x
+    | SortMaybeOpCode.inj_SortInternalOp x => SortKItem.inj_SortInternalOp x
+    | SortMaybeOpCode.inj_SortPushOp x => SortKItem.inj_SortPushOp x
+    | SortMaybeOpCode.inj_SortUnStackOp x => SortKItem.inj_SortUnStackOp x
+  retr
+    | SortKItem.inj_SortBinStackOp x => some (SortMaybeOpCode.inj_SortBinStackOp x)
+    | SortKItem.inj_SortInternalOp x => some (SortMaybeOpCode.inj_SortInternalOp x)
+    | SortKItem.inj_SortPushOp x => some (SortMaybeOpCode.inj_SortPushOp x)
+    | SortKItem.inj_SortUnStackOp x => some (SortMaybeOpCode.inj_SortUnStackOp x)
+    | SortKItem.inj_SortMaybeOpCode x => some x
+    | _ => none
+
+instance : Inj SortCallDataCell SortKItem where
+  inj := SortKItem.inj_SortCallDataCell
+  retr
+    | SortKItem.inj_SortCallDataCell x => some x
+    | _ => none
+
+instance : Inj SortTxPendingCell SortKItem where
+  inj := SortKItem.inj_SortTxPendingCell
+  retr
+    | SortKItem.inj_SortTxPendingCell x => some x
+    | _ => none
+
+instance : Inj SortCallerCell SortKItem where
+  inj := SortKItem.inj_SortCallerCell
+  retr
+    | SortKItem.inj_SortCallerCell x => some x
+    | _ => none
+
+instance : Inj SortStatusCodeCell SortKItem where
+  inj := SortKItem.inj_SortStatusCodeCell
+  retr
+    | SortKItem.inj_SortStatusCodeCell x => some x
+    | _ => none
+
+instance : Inj SortTxType SortKItem where
+  inj := SortKItem.inj_SortTxType
+  retr
+    | SortKItem.inj_SortTxType x => some x
+    | _ => none
+
+instance : Inj SortTxNonceCell SortKItem where
+  inj := SortKItem.inj_SortTxNonceCell
+  retr
+    | SortKItem.inj_SortTxNonceCell x => some x
+    | _ => none
+
+instance : Inj SortScheduleFlag SortKItem where
+  inj := SortKItem.inj_SortScheduleFlag
+  retr
+    | SortKItem.inj_SortScheduleFlag x => some x
+    | _ => none
+
+instance : Inj SortBlobGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortBlobGasUsedCell
+  retr
+    | SortKItem.inj_SortBlobGasUsedCell x => some x
+    | _ => none
+
+instance : Inj SortBlockhashesCell SortKItem where
+  inj := SortKItem.inj_SortBlockhashesCell
+  retr
+    | SortKItem.inj_SortBlockhashesCell x => some x
+    | _ => none
+
 instance : Inj SortInt SortGas where
   inj := SortGas.inj_SortInt
   retr
     | SortGas.inj_SortInt x => some x
 
+instance : Inj SortAccount SortJSON where
+  inj
+    | SortAccount.inj_SortInt x => SortJSON.inj_SortInt x
+    | x => SortJSON.inj_SortAccount x
+  retr
+    | SortJSON.inj_SortInt x => some (SortAccount.inj_SortInt x)
+    | SortJSON.inj_SortAccount x => some x
+    | _ => none
+
 instance : Inj SortMap SortJSON where
   inj := SortJSON.inj_SortMap
   retr
     | SortJSON.inj_SortMap x => some x
+    | _ => none
+
+instance : Inj SortInt SortJSON where
+  inj := SortJSON.inj_SortInt
+  retr
+    | SortJSON.inj_SortInt x => some x
     | _ => none
 
 instance : Inj SortBool SortJSON where
@@ -837,36 +860,27 @@ instance : Inj SortTxType SortJSON where
     | SortJSON.inj_SortTxType x => some x
     | _ => none
 
-instance : Inj SortInt SortJSON where
-  inj := SortJSON.inj_SortInt
-  retr
-    | SortJSON.inj_SortInt x => some x
-    | _ => none
-
-instance : Inj SortAccount SortJSON where
-  inj
-    | SortAccount.inj_SortInt x => SortJSON.inj_SortInt x
-    | x => SortJSON.inj_SortAccount x
-  retr
-    | SortJSON.inj_SortInt x => some (SortAccount.inj_SortInt x)
-    | SortJSON.inj_SortAccount x => some x
-    | _ => none
-
 instance : Inj SortInt SortJSONKey where
   inj := SortJSONKey.inj_SortInt
   retr
     | SortJSONKey.inj_SortInt x => some x
 
-instance : Inj SortPushOp SortMaybeOpCode where
-  inj := SortMaybeOpCode.inj_SortPushOp
+instance : Inj SortUnStackOp SortMaybeOpCode where
+  inj := SortMaybeOpCode.inj_SortUnStackOp
   retr
-    | SortMaybeOpCode.inj_SortPushOp x => some x
+    | SortMaybeOpCode.inj_SortUnStackOp x => some x
     | _ => none
 
 instance : Inj SortInternalOp SortMaybeOpCode where
   inj := SortMaybeOpCode.inj_SortInternalOp
   retr
     | SortMaybeOpCode.inj_SortInternalOp x => some x
+    | _ => none
+
+instance : Inj SortPushOp SortMaybeOpCode where
+  inj := SortMaybeOpCode.inj_SortPushOp
+  retr
+    | SortMaybeOpCode.inj_SortPushOp x => some x
     | _ => none
 
 instance : Inj SortBinStackOp SortMaybeOpCode where

--- a/EvmEquivalence/KEVM2Lean/Rewrite.lean
+++ b/EvmEquivalence/KEVM2Lean/Rewrite.lean
@@ -240,6 +240,197 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
             block := _Gen21 },
           network := _DotVar2 } },
       generatedCounter := _DotVar0 }
+  | SLOAD_SUMMARY_SLOAD_SUMMARY_1
+    {ACCESSEDSTORAGE_CELL STORAGE_CELL _Val22 : SortMap}
+    {GAS_CELL ID_CELL PC_CELL W0 _Val10 _Val11 _Val13 _Val14 _Val15 _Val16 _Val2 _Val3 _Val4 : SortInt}
+    {K_CELL : SortK}
+    {SCHEDULE_CELL : SortSchedule}
+    {USEGAS_CELL _Val0 _Val1 _Val12 _Val5 _Val6 _Val7 : SortBool}
+    {WS : SortWordStack}
+    {_DotVar0 : SortGeneratedCounterCell}
+    {_DotVar6 _Val23 _Val24 _Val8 _Val9 : SortAccountCellMap}
+    {_Gen0 : SortProgramCell}
+    {_Gen1 : SortJumpDestsCell}
+    {_Gen10 : SortSelfDestructCell}
+    {_Gen11 : SortLogCell}
+    {_Gen12 : SortRefundCell}
+    {_Gen13 : SortAccessedAccountsCell}
+    {_Gen14 : SortCreatedAccountsCell}
+    {_Gen15 : SortOutputCell}
+    {_Gen16 : SortStatusCodeCell}
+    {_Gen17 : SortCallStackCell}
+    {_Gen18 : SortInterimStatesCell}
+    {_Gen19 : SortTouchedAccountsCell}
+    {_Gen2 : SortCallerCell}
+    {_Gen20 : SortVersionedHashesCell}
+    {_Gen21 : SortGasPriceCell}
+    {_Gen22 : SortOriginCell}
+    {_Gen23 : SortBlockhashesCell}
+    {_Gen24 : SortBlockCell}
+    {_Gen25 : SortBalanceCell}
+    {_Gen26 : SortCodeCell}
+    {_Gen27 : SortOrigStorageCell}
+    {_Gen28 : SortTransientStorageCell}
+    {_Gen29 : SortNonceCell}
+    {_Gen3 : SortCallDataCell}
+    {_Gen30 : SortChainIDCell}
+    {_Gen31 : SortTxOrderCell}
+    {_Gen32 : SortTxPendingCell}
+    {_Gen33 : SortMessagesCell}
+    {_Gen34 : SortWithdrawalsPendingCell}
+    {_Gen35 : SortWithdrawalsOrderCell}
+    {_Gen36 : SortWithdrawalsCell}
+    {_Gen37 : SortExitCodeCell}
+    {_Gen38 : SortModeCell}
+    {_Gen4 : SortCallValueCell}
+    {_Gen5 : SortLocalMemCell}
+    {_Gen6 : SortMemoryUsedCell}
+    {_Gen7 : SortCallGasCell}
+    {_Gen8 : SortStaticCell}
+    {_Gen9 : SortCallDepthCell}
+    {_Val17 _Val19 _Val20 _Val21 : SortSet}
+    {_Val18 : SortKItem}
+    (defn_Val0 : «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag SCHEDULE_CELL = some _Val0)
+    (defn_Val1 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val1)
+    (defn_Val2 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val2)
+    (defn_Val3 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val3)
+    (defn_Val4 : kite _Val1 _Val2 _Val3 = some _Val4)
+    (defn_Val5 : «_<=Int_» _Val4 GAS_CELL = some _Val5)
+    (defn_Val6 : _andBool_ _Val0 _Val5 = some _Val6)
+    (defn_Val7 : _andBool_ USEGAS_CELL _Val6 = some _Val7)
+    (defn_Val8 : AccountCellMapItem { val := ID_CELL } {
+      acctID := { val := ID_CELL },
+      balance := _Gen25,
+      code := _Gen26,
+      storage := { val := STORAGE_CELL },
+      origStorage := _Gen27,
+      transientStorage := _Gen28,
+      nonce := _Gen29 } = some _Val8)
+    (defn_Val9 : _AccountCellMap_ _Val8 _DotVar6 = some _Val9)
+    (defn_Val10 : lookup STORAGE_CELL W0 = some _Val10)
+    (defn_Val11 : «_+Int_» PC_CELL 1 = some _Val11)
+    (defn_Val12 : «#inStorage» ACCESSEDSTORAGE_CELL ((@inj SortInt SortAccount) ID_CELL) W0 = some _Val12)
+    (defn_Val13 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val13)
+    (defn_Val14 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val14)
+    (defn_Val15 : kite _Val12 _Val13 _Val14 = some _Val15)
+    (defn_Val16 : «_-Int_» GAS_CELL _Val15 = some _Val16)
+    (defn_Val17 : «.Set» = some _Val17)
+    (defn_Val18 : «Map:lookupOrDefault» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val17) = some _Val18)
+    (defn_Val19 : «project:Set» (SortK.kseq _Val18 SortK.dotk) = some _Val19)
+    (defn_Val20 : SetItem ((@inj SortInt SortKItem) W0) = some _Val20)
+    (defn_Val21 : «_|Set__SET_Set_Set_Set» _Val19 _Val20 = some _Val21)
+    (defn_Val22 : «Map:update» ACCESSEDSTORAGE_CELL ((@inj SortInt SortKItem) ID_CELL) ((@inj SortSet SortKItem) _Val21) = some _Val22)
+    (defn_Val23 : AccountCellMapItem { val := ID_CELL } {
+      acctID := { val := ID_CELL },
+      balance := _Gen25,
+      code := _Gen26,
+      storage := { val := STORAGE_CELL },
+      origStorage := _Gen27,
+      transientStorage := _Gen28,
+      nonce := _Gen29 } = some _Val23)
+    (defn_Val24 : _AccountCellMap_ _Val23 _DotVar6 = some _Val24)
+    (req : _Val7 = true)
+    : Rewrites {
+      kevm := {
+        k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortUnStackOp SortMaybeOpCode) SortUnStackOp.SLOAD_EVM_UnStackOp))) K_CELL },
+        exitCode := _Gen37,
+        mode := _Gen38,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := USEGAS_CELL },
+        ethereum := {
+          evm := {
+            output := _Gen15,
+            statusCode := _Gen16,
+            callStack := _Gen17,
+            interimStates := _Gen18,
+            touchedAccounts := _Gen19,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := { val := (@inj SortInt SortAccount) ID_CELL },
+              caller := _Gen2,
+              callData := _Gen3,
+              callValue := _Gen4,
+              wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W0 WS },
+              localMem := _Gen5,
+              pc := { val := PC_CELL },
+              gas := { val := (@inj SortInt SortGas) GAS_CELL },
+              memoryUsed := _Gen6,
+              callGas := _Gen7,
+              static := _Gen8,
+              callDepth := _Gen9 },
+            versionedHashes := _Gen20,
+            substate := {
+              selfDestruct := _Gen10,
+              log := _Gen11,
+              refund := _Gen12,
+              accessedAccounts := _Gen13,
+              accessedStorage := { val := ACCESSEDSTORAGE_CELL },
+              createdAccounts := _Gen14 },
+            gasPrice := _Gen21,
+            origin := _Gen22,
+            blockhashes := _Gen23,
+            block := _Gen24 },
+          network := {
+            chainID := _Gen30,
+            accounts := { val := _Val9 },
+            txOrder := _Gen31,
+            txPending := _Gen32,
+            messages := _Gen33,
+            withdrawalsPending := _Gen34,
+            withdrawalsOrder := _Gen35,
+            withdrawals := _Gen36 } } },
+      generatedCounter := _DotVar0 } {
+      kevm := {
+        k := { val := K_CELL },
+        exitCode := _Gen37,
+        mode := _Gen38,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := true },
+        ethereum := {
+          evm := {
+            output := _Gen15,
+            statusCode := _Gen16,
+            callStack := _Gen17,
+            interimStates := _Gen18,
+            touchedAccounts := _Gen19,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := { val := (@inj SortInt SortAccount) ID_CELL },
+              caller := _Gen2,
+              callData := _Gen3,
+              callValue := _Gen4,
+              wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» _Val10 WS },
+              localMem := _Gen5,
+              pc := { val := _Val11 },
+              gas := { val := (@inj SortInt SortGas) _Val16 },
+              memoryUsed := _Gen6,
+              callGas := _Gen7,
+              static := _Gen8,
+              callDepth := _Gen9 },
+            versionedHashes := _Gen20,
+            substate := {
+              selfDestruct := _Gen10,
+              log := _Gen11,
+              refund := _Gen12,
+              accessedAccounts := _Gen13,
+              accessedStorage := { val := _Val22 },
+              createdAccounts := _Gen14 },
+            gasPrice := _Gen21,
+            origin := _Gen22,
+            blockhashes := _Gen23,
+            block := _Gen24 },
+          network := {
+            chainID := _Gen30,
+            accounts := { val := _Val24 },
+            txOrder := _Gen31,
+            txPending := _Gen32,
+            messages := _Gen33,
+            withdrawalsPending := _Gen34,
+            withdrawalsOrder := _Gen35,
+            withdrawals := _Gen36 } } },
+      generatedCounter := _DotVar0 }
   | SSTORE_SUMMARY_SSTORE_SUMMARY_1
     {ACCESSEDSTORAGE_CELL ORIG_STORAGE_CELL STORAGE_CELL _Val39 _Val40 : SortMap}
     {GAS_CELL ID_CELL PC_CELL REFUND_CELL W0 W1 _Val1 _Val10 _Val11 _Val13 _Val2 _Val21 _Val22 _Val23 _Val24 _Val25 _Val27 _Val28 _Val29 _Val3 _Val30 _Val31 _Val32 _Val33 _Val6 _Val7 _Val8 _Val9 : SortInt}

--- a/EvmEquivalence/KEVM2Lean/Sorts.lean
+++ b/EvmEquivalence/KEVM2Lean/Sorts.lean
@@ -85,6 +85,10 @@ inductive SortSchedule : Type where
   | TANGERINE_WHISTLE_EVM : SortSchedule
   deriving BEq, DecidableEq
 
+inductive SortUnStackOp : Type where
+  | SLOAD_EVM_UnStackOp : SortUnStackOp
+  deriving BEq, DecidableEq
+
 inductive SortTxType : Type where
   | «.TxType_EVM-TYPES_TxType» : SortTxType
   | «AccessList_EVM-TYPES_TxType» : SortTxType
@@ -390,6 +394,7 @@ mutual
     | inj_SortBinStackOp (x : SortBinStackOp) : SortMaybeOpCode
     | inj_SortInternalOp (x : SortInternalOp) : SortMaybeOpCode
     | inj_SortPushOp (x : SortPushOp) : SortMaybeOpCode
+    | inj_SortUnStackOp (x : SortUnStackOp) : SortMaybeOpCode
     deriving BEq, DecidableEq
 end
 
@@ -715,6 +720,7 @@ mutual
     | inj_SortTxType (x : SortTxType) : SortKItem
     | inj_SortTxTypeCell (x : SortTxTypeCell) : SortKItem
     | inj_SortTxVersionedHashesCell (x : SortTxVersionedHashesCell) : SortKItem
+    | inj_SortUnStackOp (x : SortUnStackOp) : SortKItem
     | inj_SortUseGasCell (x : SortUseGasCell) : SortKItem
     | inj_SortValidatorIndexCell (x : SortValidatorIndexCell) : SortKItem
     | inj_SortValueCell (x : SortValueCell) : SortKItem

--- a/EvmEquivalence/StateMap.lean
+++ b/EvmEquivalence/StateMap.lean
@@ -207,6 +207,7 @@ end StateMap
 open StateMap
 
 namespace Axioms
+-- Axioms that have to do with the axiomatic state mapping
 
 /--
 This axiom states that if an account is in an `AccountCellMap`, then
@@ -346,5 +347,26 @@ axiom accessedStorageCell_map_insert
   (Axioms.SortAccessedStorageCellMap { val := ACCESSEDSTORAGE_CELL }).insert
     (AccountAddress.ofNat (Int.toNat ID_CELL), intMap key) =
   Axioms.SortAccessedStorageCellMap { val := stor_update }
+
+/--
+Mapping a `SortStorageCell` through `Axioms.SortStorageCellMap` results
+in an equivalence of behavior between K's `lookup` function and EvmYul's `findD`.
+Provided that `lookup` results in `some result`.
+-/
+axiom lookup_mapped_storage (storage : SortMap) (key result : SortInt) (_ : lookup storage key = some result):
+  Batteries.RBMap.findD (Axioms.SortStorageCellMap { val := storage }) (intMap key) { val := 0 } = intMap result
+
+
+/--
+Mapping a `SortAccessedStorageCell` through `Axioms.SortAccessedStorageCellMap` results
+in an equivalence of behavior between K's `«#inStorage»` function and EvmYul's `RBSet.contains`.
+-/
+axiom contains_accessedStorage_map
+  {contained : Bool}
+  {stor : SortMap}
+  {acc key : SortInt}
+  (_ : «#inStorage» stor (SortAccount.inj_SortInt acc) key = some contained):
+  (Axioms.SortAccessedStorageCellMap { val := stor }).contains
+  (AccountAddress.ofNat (Int.toNat acc), intMap key) = contained
 
 end Axioms

--- a/EvmEquivalence/Summaries/SloadSummary.lean
+++ b/EvmEquivalence/Summaries/SloadSummary.lean
@@ -1,0 +1,195 @@
+import EvmYul.EVM.Semantics
+import EvmYul.EVM.GasConstants
+import EvmEquivalence.Interfaces.EvmYulInterface
+
+open EvmYul
+open EVM
+open EvmYul.State
+
+namespace SloadSummary
+
+section
+
+variable (gas gasCost : ℕ)
+variable (symStack : Stack UInt256)
+variable (symPc symGasAvailable symRefund key value : UInt256)
+variable (symExecLength : ℕ)
+variable (symReturnData symCode : ByteArray)
+variable (symAccessedStorageKeys : Batteries.RBSet (AccountAddress × UInt256) Substate.storageKeysCmp)
+variable (symAccounts : AccountMap)
+variable (symCodeOwner : AccountAddress)
+variable (symPerm : Bool)
+
+@[simp]
+abbrev sloadEVM := @Operation.SLOAD .EVM
+
+@[simp]
+abbrev sload_instr : Option (Operation .EVM × Option (UInt256 × Nat)) :=
+  some ⟨sloadEVM, none⟩
+
+@[simp]
+abbrev EVM.step_sload : Transformer :=
+  EVM.step false gas gasCost sload_instr
+
+@[simp]
+abbrev EvmYul.step_sload : Transformer :=
+  EvmYul.step false sloadEVM
+
+@[simp]
+def lookupStorage_sload (symState : EvmYul.State) (key : UInt256) : UInt256 :=
+  let Iₐ := symState.executionEnv.codeOwner
+  match symState.lookupAccount Iₐ with
+  | none => ⟨0⟩
+  | some acc => acc.lookupStorage key
+
+theorem sload_summary (symState : EvmYul.State) (key : UInt256):
+  let ss := {symState with
+             executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
+             substate := {symState.substate with
+                          accessedStorageKeys :=  symAccessedStorageKeys
+                          refundBalance := symRefund}
+             accountMap := symAccounts}
+  State.sload ss key =
+  (addAccessedStorageKey ss (symCodeOwner, key),
+    lookupStorage_sload ss key) := by
+  cases cco: (symState.lookupAccount symState.executionEnv.codeOwner)
+  all_goals aesop (add simp [sload, Option.option, lookupAccount, Substate.addAccessedStorageKey])
+
+/--
+Theorem needed to bypass the `private` attribute of `EVM.dispatchBinaryStateOp`
+ -/
+theorem sload_bypass_private (symState : EVM.State):
+  let ss := {symState with
+  stack := symStack,
+  pc := symPc
+  gasAvailable := symGasAvailable,
+  executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
+  substate := {symState.substate with
+               accessedStorageKeys :=  symAccessedStorageKeys
+               refundBalance := symRefund}
+  returnData := symReturnData,
+  execLength := symExecLength,
+  accountMap := symAccounts}
+  EvmYul.step_sload ss =
+  EVM.unaryStateOp false EvmYul.State.sload ss := rfl
+
+theorem EvmYul.step_sload_summary (symState : EVM.State):
+  let ss := {symState with
+    stack := key :: symStack,
+    pc := symPc
+    gasAvailable := symGasAvailable,
+    executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
+    substate := {symState.substate with
+                 accessedStorageKeys :=  symAccessedStorageKeys
+                 refundBalance := symRefund}
+    returnData := symReturnData,
+    execLength := symExecLength,
+    accountMap := symAccounts}
+  EvmYul.step_sload ss =
+  .ok {ss with
+    stack := lookupStorage_sload ss.toState key :: symStack,
+    pc := symPc + .ofNat 1
+    substate.accessedStorageKeys := ss.substate.accessedStorageKeys.insert ⟨ss.executionEnv.codeOwner, key⟩} := by
+  simp [sload_bypass_private, unaryStateOp, Stack.pop, Id.run, State.replaceStackAndIncrPC, State.incrPC, sload, lookupAccount]
+  aesop (add simp [sload_summary, Substate.addAccessedStorageKey])
+
+theorem EVM.step_sload_summary (gas_pos : 0 < gas) (symState : EVM.State):
+  let ss := {symState with
+    stack := key :: symStack,
+    pc := symPc
+    gasAvailable := symGasAvailable,
+    executionEnv := {symState.executionEnv with
+                  code := symCode,
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
+    substate := {symState.substate with
+                 accessedStorageKeys :=  symAccessedStorageKeys
+                 refundBalance := symRefund}
+    returnData := symReturnData,
+    execLength := symExecLength,
+    accountMap := symAccounts}
+  EVM.step_sload gas gasCost ss =
+    .ok {ss with
+          stack := lookupStorage_sload ss.toState key :: symStack,
+          pc := symPc + (.ofNat 1),
+          gasAvailable := symGasAvailable - UInt256.ofNat gasCost,
+          substate := {ss.substate with
+            accessedStorageKeys := ss.substate.accessedStorageKeys.insert ⟨ss.executionEnv.codeOwner, key⟩
+           }
+          execLength := symExecLength + 1} := by
+  cases gas; contradiction
+  simp [step_sload, EVM.step]
+  have srw := EvmYul.step_sload_summary symStack symPc (symGasAvailable - UInt256.ofNat gasCost) symRefund key (symExecLength + 1) symReturnData symCode symAccessedStorageKeys symAccounts symCodeOwner symPerm
+  simp [EvmYul.step_sload, Operation.SLOAD] at srw; simp [srw]
+
+@[simp]
+theorem decode_singleton_sload :
+  decode ⟨#[0x54]⟩ (.ofNat 0) = some ⟨sloadEVM, none⟩ := rfl
+
+@[simp]
+theorem memoryExpansionCost_sload (symState : EVM.State) :
+  memoryExpansionCost symState sloadEVM = 0 := by
+  simp [memoryExpansionCost, memoryExpansionCost.μᵢ']
+
+/--
+TODO: Generalize to `C'`
+ -/
+theorem Csload_pos (symState : EVM.State) : 99 < Csload symState.stack symState.substate symState.executionEnv := by
+  aesop (add simp [Csload, GasConstants.Gcoldsload, GasConstants.Gwarmaccess])
+
+theorem X_sload_summary (symState : EVM.State)
+                         (symStack_ok : symStack.length < 1024):
+  let ss := {symState with
+    stack := key :: symStack,
+    pc := .ofNat 0
+    gasAvailable := symGasAvailable,
+    executionEnv := {symState.executionEnv with
+                  code := ⟨#[(0x54 : UInt8)]⟩,
+                  codeOwner := symCodeOwner
+                  perm := symPerm},
+    substate := {symState.substate with
+                 accessedStorageKeys :=  symAccessedStorageKeys
+                 refundBalance := symRefund}
+    returnData := symReturnData,
+    execLength := symExecLength,
+    accountMap := symAccounts}
+  Csload ss.stack ss.substate ss.executionEnv < symGasAvailable.toNat →
+  X false symGasAvailable.toNat ss =
+  .ok (.success {ss with
+          stack := lookupStorage_sload ss.toState key :: symStack,
+          pc := .ofNat 1,
+          gasAvailable := symGasAvailable - (.ofNat (Csload ss.stack ss.substate ss.executionEnv)),
+          substate := {ss.substate with
+            accessedStorageKeys := ss.substate.accessedStorageKeys.insert ⟨ss.executionEnv.codeOwner, key⟩
+           }
+          returnData := .empty,
+          execLength := symExecLength + 2} .empty) := by
+  intro ss enoughGas
+  have gavail_pos := Nat.lt_trans (Csload_pos ss) enoughGas
+  cases g_case : symGasAvailable.toNat; rw [g_case] at gavail_pos; contradiction
+  case succ g_pos =>
+  simp [X, C', δ]
+  have lt_fls_rw {n m : ℕ} (_ : n < m) : (m < n) = False := by
+    simp; apply Nat.ge_of_not_lt; simp; omega
+  simp [ss, (lt_fls_rw enoughGas), α, (lt_fls_rw symStack_ok)]
+  have stack_ok_rw : (1024 < List.length symStack + 1) = False := by
+    aesop (add safe (by linarith))
+  simp [stack_ok_rw]; split; contradiction; next evm cost stateOk =>
+  have step_rw := (EVM.step_sload_summary g_pos (Csload ss.stack ss.substate ss.executionEnv) symStack (.ofNat 0)
+    symGasAvailable symRefund key symExecLength symReturnData ⟨#[(0x54 : UInt8)]⟩
+    symAccessedStorageKeys symAccounts symCodeOwner symPerm (by omega) evm)
+  cases stateOk; simp at step_rw; rw [step_rw]; simp [Except.instMonad, Except.bind]
+  rw [X_bad_pc] <;> aesop (add safe (by omega))
+
+end
+
+end SloadSummary


### PR DESCRIPTION
This PR adds the following:
- Equivalence proofs for the `SLOAD` opcode
- Two new axioms about the axiomatic state mapping in `StateMap.lean`
  - `lookup_mapped_storage`: asserting compatibility between `RBMap.findD` and `lookup` when mapping a storage map. This axioms requires that `lookup` is not `none`
  - `contains_accessedStorage_map`: asserting compatibility between `RBMap.contains` and `#inStorage` when mapping an accessed storage map
- EvmYul summaries for the `SLOAD` opcode
- Additional Lean 4 generated code to support the KEVM semantics of `SLOAD`