### PR TITLE
`MSTORE8` opcode equivalence

### DIFF
--- a/EvmEquivalence/Equivalence/MstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/MstoreEquivalence.lean
@@ -514,7 +514,7 @@ theorem step_mstore_equiv
   -- "Due to [the fee shceme] it is highly unlikely [memory] addresses will ever go above 32-bit bounds"
   -- It seems we need this hypothesis to achieve equivalence of behavior from the EVMYul side
   -- We keep the original `W0small` for convenience
-  (W0small_realpolitik : W0 < UInt32.size):
+  (W0small_realpolitik : W0 < UInt32.size) :
   EVM.step_mstore op.from_k (Int.toNat GAS_CELL) gasCost (stateMap symState (@mstoreLHS op GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)) =
   .ok (stateMap {symState with execLength := symState.execLength + 1} (@mstoreRHS _Val17 _Val24 _Val25 _Val16 SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL))
   := by

--- a/EvmEquivalence/Equivalence/MstoreEquivalence.lean
+++ b/EvmEquivalence/Equivalence/MstoreEquivalence.lean
@@ -12,6 +12,50 @@ open MstoreSummary
 
 namespace MstoreOpcodeEquivalence
 
+inductive mstore_op where
+  | mstore
+  | mstore8
+
+variable (op : mstore_op)
+
+@[simp]
+def mstore_op.to_binop : mstore_op → SortBinStackOp
+  | .mstore  => .MSTORE_EVM_BinStackOp
+  | .mstore8 => .MSTORE8_EVM_BinStackOp
+
+def mstore_op.from_k : mstore_op → MstoreSummary.mstore_op
+  | .mstore  => .mstore
+  | .mstore8 => .mstore8
+
+@[simp]
+def mstore_op.to_width: mstore_op → ℕ
+  | .mstore  => 32
+  | .mstore8 => 1
+
+/--
+Assigns `defn_Val14` to the following propositions depending on the opcode:
+`«#asByteStack» W1 = some _Val14` for `MSTORE`
+`_modInt_ W1 256 = some _Val14` for `MSTORE8`
+ -/
+def mstore_op.to_defn_Val14
+  (v14Bytes : SortBytes)
+  (v14Int W1 : SortInt) : Prop :=
+  match op with
+  | .mstore => «#asByteStack» W1 = some v14Bytes
+  | .mstore8 => _modInt_ W1 256 = some v14Int
+
+/--
+Assigns `defn_Val15` to the following propositions depending on the opcode:
+`«#asByteStack» W1 = some _Val14` for `MSTORE`
+`_modInt_ W1 256 = some _Val14` for `MSTORE8`
+ -/
+def mstore_op.to_defn_Val15
+  (v14Bytes _Val15 : SortBytes)
+  (v14Int : SortInt) : Prop :=
+  match op with
+  | .mstore => «#padToWidth» 32 v14Bytes = some _Val15
+  | .mstore8 => buf 1 v14Int = some _Val15
+
 def mstoreLHS
   {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 : SortInt}
   {LOCALMEM_CELL : SortBytes}
@@ -44,7 +88,7 @@ def mstoreLHS
   {_Gen9 : SortOutputCell}
   {_K_CELL : SortK} : SortGeneratedTopCell :=
   { kevm := {
-      k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortBinStackOp SortMaybeOpCode) SortBinStackOp.MSTORE_EVM_BinStackOp))) _K_CELL },
+      k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortBinStackOp SortMaybeOpCode) op.to_binop))) _K_CELL },
       exitCode := _Gen20,
       mode := _Gen21,
       schedule := { val := SCHEDULE_CELL },
@@ -148,8 +192,8 @@ def mstoreRHS
     generatedCounter := _DotVar0 }
 
 theorem rw_mstoreLHS_mstoreRHS
-  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
-  {LOCALMEM_CELL _Val14 _Val15 _Val16 : SortBytes}
+  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val14mstore8 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {LOCALMEM_CELL _Val14mstore _Val15 _Val16 : SortBytes}
   {SCHEDULE_CELL : SortSchedule}
   {USEGAS_CELL _Val11 _Val12 _Val13 _Val4 : SortBool}
   {WS : SortWordStack}
@@ -178,13 +222,13 @@ theorem rw_mstoreLHS_mstoreRHS
   {_Gen8 : SortCallDepthCell}
   {_Gen9 : SortOutputCell}
   {_K_CELL : SortK}
-  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val0)
+  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val0)
   (defn_Val1 : Cmem SCHEDULE_CELL _Val0 = some _Val1)
   (defn_Val2 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val2)
   (defn_Val3 : «_-Int_» _Val1 _Val2 = some _Val3)
   (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
   (defn_Val5 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val5)
-  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val6)
+  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val6)
   (defn_Val7 : Cmem SCHEDULE_CELL _Val6 = some _Val7)
   (defn_Val8 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val8)
   (defn_Val9 : «_-Int_» _Val7 _Val8 = some _Val9)
@@ -192,24 +236,28 @@ theorem rw_mstoreLHS_mstoreRHS
   (defn_Val11 : «_<=Int_» _Val5 _Val10 = some _Val11)
   (defn_Val12 : _andBool_ _Val4 _Val11 = some _Val12)
   (defn_Val13 : _andBool_ USEGAS_CELL _Val12 = some _Val13)
-  (defn_Val14 : «#asByteStack» W1 = some _Val14)
-  (defn_Val15 : «#padToWidth» 32 _Val14 = some _Val15)
+  (defn_Val14 : op.to_defn_Val14 _Val14mstore _Val14mstore8 W1)
+  (defn_Val15 : op.to_defn_Val15 _Val14mstore _Val15 _Val14mstore8)
   (defn_Val16 : mapWriteRange LOCALMEM_CELL W0 _Val15 = some _Val16)
   (defn_Val17 : «_+Int_» PC_CELL 1 = some _Val17)
-  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val18)
+  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val18)
   (defn_Val19 : Cmem SCHEDULE_CELL _Val18 = some _Val19)
   (defn_Val20 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val20)
   (defn_Val21 : «_-Int_» _Val19 _Val20 = some _Val21)
   (defn_Val22 : «_-Int_» GAS_CELL _Val21 = some _Val22)
   (defn_Val23 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val23)
   (defn_Val24 : «_-Int_» _Val22 _Val23 = some _Val24)
-  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val25)
+  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val25)
   (req : _Val13 = true) :
   Rewrites
-  (@mstoreLHS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)
+  (@mstoreLHS op GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)
   (@mstoreRHS _Val17 _Val24 _Val25 _Val16 SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)
-  := by apply (@Rewrites.MSTORE_SUMMARY_MSTORE_SUMMARY_USEGAS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8)
-  <;> assumption
+  := by
+  cases op
+  . apply (@Rewrites.MSTORE_SUMMARY_MSTORE_SUMMARY_USEGAS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8)
+    <;> assumption
+  . apply (@Rewrites.MSTORE8_SUMMARY_MSTORE8_SUMMARY_USEGAS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val14mstore8 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8)
+    <;> assumption
 
 theorem mstore_prestate_equiv
   {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 : SortInt}
@@ -243,7 +291,7 @@ theorem mstore_prestate_equiv
   {_Gen9 : SortOutputCell}
   {_K_CELL : SortK}
   (symState : EVM.State) :
-  let lhs := (@mstoreLHS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)
+  let lhs := (@mstoreLHS op GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)
   stateMap symState lhs =
   {symState with
     stack := (intMap W0) :: (intMap W1) :: wordStackMap WS
@@ -306,18 +354,20 @@ theorem mstore_poststate_equiv
 
 theorem activeWords_eq
   {MEMORYUSED_CELL W0 _Val25: SortInt}
-  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val25)
+  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val25)
   (W0ge0 : 0 ≤ W0)
   (W0small : W0 < UInt256.size)
   (mucge0 : 0 ≤ MEMORYUSED_CELL)
   (mucsmall : MEMORYUSED_CELL < UInt256.size) :
-  activeWords_comp (intMap W0) (intMap MEMORYUSED_CELL) = intMap _Val25 := by
+  activeWords_comp (intMap W0) (intMap MEMORYUSED_CELL) op.to_width = intMap _Val25 := by
   unfold activeWords_comp
   rw [memoryUsageUpdate_rw, Option.some.injEq] at defn_Val25
+  case width_pos => aesop
   simp [←defn_Val25, intMap]; rw [UInt256.ofNat_toSigned]
   simp [UInt256.toSigned]; cases mucc: MEMORYUSED_CELL
   <;> try (rw [mucc] at mucge0; contradiction)
   cases wc: W0 <;> try (rw [wc] at W0ge0; contradiction)
+  cases op <;>
   aesop (add simp [UInt256.ofNat_toNat]) (add safe (by omega)) (add safe (by congr))
 
 theorem mstore_memory_write_eq
@@ -388,8 +438,8 @@ theorem mstore_memory_write_eq
   aesop (add simp [UInt32.size]) (add safe (by omega))
 
 theorem step_mstore_equiv
-  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
-  {LOCALMEM_CELL _Val14 _Val15 _Val16 : SortBytes}
+  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val14mstore8 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {LOCALMEM_CELL _Val14mstore _Val15 _Val16 : SortBytes}
   {SCHEDULE_CELL : SortSchedule}
   {USEGAS_CELL _Val11 _Val12 _Val13 _Val4 : SortBool}
   {WS : SortWordStack}
@@ -418,13 +468,13 @@ theorem step_mstore_equiv
   {_Gen8 : SortCallDepthCell}
   {_Gen9 : SortOutputCell}
   {_K_CELL : SortK}
-  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val0)
+  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val0)
   (defn_Val1 : Cmem SCHEDULE_CELL _Val0 = some _Val1)
   (defn_Val2 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val2)
   (defn_Val3 : «_-Int_» _Val1 _Val2 = some _Val3)
   (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
   (defn_Val5 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val5)
-  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val6)
+  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val6)
   (defn_Val7 : Cmem SCHEDULE_CELL _Val6 = some _Val7)
   (defn_Val8 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val8)
   (defn_Val9 : «_-Int_» _Val7 _Val8 = some _Val9)
@@ -432,18 +482,18 @@ theorem step_mstore_equiv
   (defn_Val11 : «_<=Int_» _Val5 _Val10 = some _Val11)
   (defn_Val12 : _andBool_ _Val4 _Val11 = some _Val12)
   (defn_Val13 : _andBool_ USEGAS_CELL _Val12 = some _Val13)
-  (defn_Val14 : «#asByteStack» W1 = some _Val14)
-  (defn_Val15 : «#padToWidth» 32 _Val14 = some _Val15)
+  (defn_Val14 : op.to_defn_Val14 _Val14mstore _Val14mstore8 W1)
+  (defn_Val15 : op.to_defn_Val15 _Val14mstore _Val15 _Val14mstore8)
   (defn_Val16 : mapWriteRange LOCALMEM_CELL W0 _Val15 = some _Val16)
   (defn_Val17 : «_+Int_» PC_CELL 1 = some _Val17)
-  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val18)
+  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val18)
   (defn_Val19 : Cmem SCHEDULE_CELL _Val18 = some _Val19)
   (defn_Val20 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val20)
   (defn_Val21 : «_-Int_» _Val19 _Val20 = some _Val21)
   (defn_Val22 : «_-Int_» GAS_CELL _Val21 = some _Val22)
   (defn_Val23 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val23)
   (defn_Val24 : «_-Int_» _Val22 _Val23 = some _Val24)
-  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val25)
+  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val25)
   (req : _Val13 = true)
   (symState : EVM.State)
   -- Necessary for EVM.step
@@ -464,28 +514,40 @@ theorem step_mstore_equiv
   -- "Due to [the fee shceme] it is highly unlikely [memory] addresses will ever go above 32-bit bounds"
   -- It seems we need this hypothesis to achieve equivalence of behavior from the EVMYul side
   -- We keep the original `W0small` for convenience
-  (W0small_realpolitik : W0 < UInt32.size) :
-  EVM.step_mstore (Int.toNat GAS_CELL) gasCost (stateMap symState (@mstoreLHS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)) =
+  (W0small_realpolitik : W0 < UInt32.size):
+  EVM.step_mstore op.from_k (Int.toNat GAS_CELL) gasCost (stateMap symState (@mstoreLHS op GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)) =
   .ok (stateMap {symState with execLength := symState.execLength + 1} (@mstoreRHS _Val17 _Val24 _Val25 _Val16 SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL))
   := by
   cases cg: (Int.toNat GAS_CELL)
   next =>
     rw [Int.toNat_eq_zero] at cg
     have _ := Int.lt_of_lt_of_le gavailEnough cg; contradiction
-  cases _Gen15; rw [mstore_prestate_equiv]; simp [mstoreLHS]
-  rw [←EVM.step_mstore, EVM.step_mstore_summary] <;> first | assumption | try simp
+  rename_i g
+  cases _Gen15 with
+  | mk selfDestruct log refund accessedAccounts accessedStorage createdAccounts =>
+  rw [mstore_prestate_equiv]; simp [mstoreLHS]
+  have ms_rw := EVM.step_mstore_summary op.from_k
+  unfold EVM.step_mstore mstore_op.get at ms_rw
+  rw [ms_rw] <;> first | assumption | try simp
   rw [mstore_poststate_equiv, mstoreRHS] <;> first | assumption | try simp
   simp [activeWords_comp, mstore_memory_write]
   constructor; constructor <;> try constructor
   . sorry -- Gas goals are for now unproven
-  . rw [←activeWords_comp, activeWords_eq defn_Val25] <;> assumption
-  . rw [←mstore_memory_write, mstore_memory_write_eq defn_Val14 defn_Val15 defn_Val16]
-    <;> assumption
+  . have aw_rw := activeWords_eq op defn_Val25
+    cases op <;> simp [mstore_op.from_k] <;> aesop
+  . cases op <;> simp [mstore_op.from_k]
+    . rw [mstore_memory_write_eq defn_Val14 defn_Val15 defn_Val16] <;> assumption
+    . -- `mstore8_memory_write (intMap W0) (intMap W1) LOCALMEM_CELL = _Val16`
+      sorry
+      -- We need to provde a `mstore8_memory_write_eq` theorem
+      -- similar to `mstore_memory_write_eq`.
+      -- Then, something like the following should solve it:
+      -- `rw [mstore8_memory_write_eq defn_Val14 defn_Val15 defn_Val16] <;> assumption`
   . rw [←UInt256.add_succ_mod_size, intMap_add_dist] <;> aesop
 
 theorem X_mstore_equiv
-  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
-  {LOCALMEM_CELL _Val14 _Val15 _Val16 : SortBytes}
+  {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val14mstore8 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
+  {LOCALMEM_CELL _Val14mstore _Val15 _Val16 : SortBytes}
   {SCHEDULE_CELL : SortSchedule}
   {USEGAS_CELL _Val11 _Val12 _Val13 _Val4 : SortBool}
   {WS : SortWordStack}
@@ -514,13 +576,13 @@ theorem X_mstore_equiv
   {_Gen8 : SortCallDepthCell}
   {_Gen9 : SortOutputCell}
   {_K_CELL : SortK}
-  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val0)
+  (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val0)
   (defn_Val1 : Cmem SCHEDULE_CELL _Val0 = some _Val1)
   (defn_Val2 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val2)
   (defn_Val3 : «_-Int_» _Val1 _Val2 = some _Val3)
   (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
   (defn_Val5 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val5)
-  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val6)
+  (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val6)
   (defn_Val7 : Cmem SCHEDULE_CELL _Val6 = some _Val7)
   (defn_Val8 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val8)
   (defn_Val9 : «_-Int_» _Val7 _Val8 = some _Val9)
@@ -528,18 +590,18 @@ theorem X_mstore_equiv
   (defn_Val11 : «_<=Int_» _Val5 _Val10 = some _Val11)
   (defn_Val12 : _andBool_ _Val4 _Val11 = some _Val12)
   (defn_Val13 : _andBool_ USEGAS_CELL _Val12 = some _Val13)
-  (defn_Val14 : «#asByteStack» W1 = some _Val14)
-  (defn_Val15 : «#padToWidth» 32 _Val14 = some _Val15)
+  (defn_Val14 : op.to_defn_Val14 _Val14mstore _Val14mstore8 W1)
+  (defn_Val15 : op.to_defn_Val15 _Val14mstore _Val15 _Val14mstore8)
   (defn_Val16 : mapWriteRange LOCALMEM_CELL W0 _Val15 = some _Val16)
   (defn_Val17 : «_+Int_» PC_CELL 1 = some _Val17)
-  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val18)
+  (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val18)
   (defn_Val19 : Cmem SCHEDULE_CELL _Val18 = some _Val19)
   (defn_Val20 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val20)
   (defn_Val21 : «_-Int_» _Val19 _Val20 = some _Val21)
   (defn_Val22 : «_-Int_» GAS_CELL _Val21 = some _Val22)
   (defn_Val23 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val23)
   (defn_Val24 : «_-Int_» _Val22 _Val23 = some _Val24)
-  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 32 = some _Val25)
+  (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 op.to_width = some _Val25)
   (req : _Val13 = true)
   (symState : EVM.State)
   (symValidJumps : Array UInt256) -- TODO: Revisit
@@ -555,7 +617,7 @@ theorem X_mstore_equiv
   (W1small : W1 < UInt256.size)
   (mucge0 : 0 ≤ MEMORYUSED_CELL)
   (mucsmall : MEMORYUSED_CELL < UInt256.size)
-  (codeMstore : _Gen0 = ⟨⟨#[(0x52 : UInt8)]⟩⟩)
+  (codeMstore : _Gen0 = ⟨op.from_k.to_bin⟩)
   (pcZero : PC_CELL = 0)
   -- TODO: Replace with a native measure for `SortWordStack` and
   -- prove this assumption via an equality theorem stating that
@@ -567,7 +629,7 @@ theorem X_mstore_equiv
   -- We keep the original `W0small` for convenience
   (W0small_realpolitik : W0 < UInt32.size) :
   EVM.X (UInt256.toNat (intMap GAS_CELL)) symValidJumps
-  (stateMap symState (@mstoreLHS GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)) =
+  (stateMap symState (@mstoreLHS op GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 LOCALMEM_CELL SCHEDULE_CELL USEGAS_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 _Gen9 _K_CELL)) =
   .ok (.success (stateMap {symState with execLength := symState.execLength + 2} (@mstoreRHS _Val17 _Val24 _Val25 _Val16 SCHEDULE_CELL WS _DotVar0 _DotVar2 _Gen0 _Gen1 _Gen10 _Gen11 _Gen12 _Gen13 _Gen14 _Gen15 _Gen16 _Gen17 _Gen18 _Gen19 _Gen2 _Gen20 _Gen21 _Gen3 _Gen4 _Gen5 _Gen6 _Gen7 _Gen8 ⟨.empty⟩ _K_CELL)) .empty)
   := by
   cases cg: (Int.toNat GAS_CELL)
@@ -582,17 +644,26 @@ theorem X_mstore_equiv
   simp [mstoreLHS, mstoreRHS]; rw [pc_equiv, X_mstore_summary] <;> try assumption
   . simp; constructor <;> try constructor <;> try constructor
     . -- Gas correctness goal
-      simp [memoryExpansionCost_mstore _ (intMap W0) (intMap MEMORYUSED_CELL)]
-      simp [EVM.Cₘ]
+      /- rw [memoryExpansionCost_mstore op (wordStackMap WS) (intMap W0) (intMap MEMORYUSED_CELL)]
+      simp [EVM.Cₘ] -/
       sorry
-    . rw [activeWords_eq defn_Val25] <;> assumption
-    . rw [mstore_memory_write_eq defn_Val14 defn_Val15 defn_Val16] <;> assumption
+    . have aw_rw := activeWords_eq op defn_Val25
+      cases op <;> simp [mstore_op.from_k] <;> aesop
+    . cases op <;> simp [mstore_op.from_k]
+      . rw [mstore_memory_write_eq defn_Val14 defn_Val15 defn_Val16] <;> assumption
+      . -- `mstore8_memory_write (intMap W0) (intMap W1) LOCALMEM_CELL = _Val16`
+        sorry
+      -- We need to provde a `mstore8_memory_write_eq` theorem
+      -- similar to `mstore_memory_write_eq`.
+      -- Then, something like the following should solve it:
+      -- `rw [mstore8_memory_write_eq defn_Val14 defn_Val15 defn_Val16] <;> assumption`
     . aesop
   . -- Enough Gas
-    simp [EVM.memoryExpansionCost, EVM.Cₘ, EVM.memoryExpansionCost.μᵢ', MachineState.M]
     sorry
   . -- Gas is not greater than `UInt256.size`
     simp [EVM.memoryExpansionCost, EVM.Cₘ, EVM.memoryExpansionCost.μᵢ', MachineState.M]
+    sorry
+  . -- `memoryExpansionCost < UInt256.size`
     sorry
 
 end MstoreOpcodeEquivalence

--- a/EvmEquivalence/Interfaces/FuncInterface.lean
+++ b/EvmEquivalence/Interfaces/FuncInterface.lean
@@ -193,9 +193,11 @@ theorem accountAddressIsSome (n : ℕ) (size : n < AccountAddress.size) : Accoun
   simp [AccountAddress.ofNat, Fin.ofNat]; aesop
 
 attribute [local simp] «_<Int_» «_+Int_» «_<=Int_» «_-Int_» «_/Int_» «_=/=Int_» «_==Int_»
-theorem memoryUsageUpdate_rw (MEMORYUSED_CELL offset : SortInt) :
-  «#memoryUsageUpdate» MEMORYUSED_CELL offset 32 =
-  some (MEMORYUSED_CELL ⊔ Int.tdiv (offset + 32 + 31) 32) := by
+theorem memoryUsageUpdate_rw
+  (MEMORYUSED_CELL offset width : SortInt)
+  (width_pos : 0 < width):
+  «#memoryUsageUpdate» MEMORYUSED_CELL offset width =
+  some (MEMORYUSED_CELL ⊔ Int.tdiv (offset + width + 31) 32) := by
   simp [«#memoryUsageUpdate», _8096892, _86ca6df, notBool_def, Option.bind]
   simp [«maxInt(_,_)_INT-COMMON_Int_Int_Int», «_up/Int__EVM-TYPES_Int_Int_Int»]
   simp [_091b7da, _50d266e, _e985b28, _5321d80 ]

--- a/EvmEquivalence/KEVM2Lean/Func.lean
+++ b/EvmEquivalence/KEVM2Lean/Func.lean
@@ -1,569 +1,240 @@
 import EvmEquivalence.KEVM2Lean.Inj
 import EvmEquivalence.KEVM2Lean.ScheduleOrdering
 
-axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
-
-def SCHEDULE_GhasextcodehashDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def _991a329 : SortBool → SortBool → Option SortBool
-  | false, B => some B
-  | _, _ => none
-
-def SCHEDULE_GhasmaxinitcodesizeShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasprevrandaoMerge : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.MERGE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GselfdestructnewaccountTangerine : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhassstorestipendIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasshiftDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_Ghascreate2Constantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_Ghaseip6780Cancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasselfbalanceDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhaschainidIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstorePetersburg : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.PETERSBURG_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GstaticcalldepthTangerine : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_Ghaseip6780Default : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def _7174452 : SortBool → SortBool → Option SortBool
-  | true, _Gen0 => some true
-  | _, _ => none
-
-def SCHEDULE_GemptyisnonexistentDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasmaxinitcodesizeDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasextcodehashConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasreturndataDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GstaticcalldepthDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasrejectedfirstbyteDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasstaticcallDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobbasefeeCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GzerovaluenewaccountgasDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasaccesslistDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def _53fc758 : SortBool → Option SortBool
-  | true => some false
-  | _ => none
-
-def SCHEDULE_GhasshiftConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaswarmcoinbaseShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaswarmcoinbaseDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobhashCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasselfbalanceIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaswithdrawalsShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaspushzeroDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
-
-def SCHEDULE_GhasstaticcallByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasmcopyCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhastransientCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhassstorestipendDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasbasefeeLondon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasrejectedfirstbyteLondon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhastransientDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhaschainidDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobhashDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def _17ebc68 : SortBool → Option SortBool
-  | false => some true
-  | _ => none
-
-def SCHEDULE_hasaccesslistBerlin : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.BERLIN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasbeaconrootCancun : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasreturndataByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_Ghascreate2Default : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasrevertDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasbeaconrootDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GzerovaluenewaccountgasDragon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasprevrandaoDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
 def SCHEDULE_GhaswithdrawalsDefault : SortScheduleFlag → SortSchedule → Option SortBool
   | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasrevertByzantium : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GselfdestructnewaccountDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasblobbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GhasdirtysstoreConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhaspushzeroShanghai : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GhasmcopyDefault : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
-  | _, _ => none
-
-def SCHEDULE_GemptyisnonexistentDragon : SortScheduleFlag → SortSchedule → Option SortBool
-  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some true
-  | _, _ => none
-
-def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
-  | _, _ => none
-
-def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
-  | _, _ => none
-
-def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
-  | _, _ => none
-
-def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
-  | _, _ => none
-
-def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
-  | _, _ => none
-
-def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
-  | _, _ => none
-
-def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
-  | _, _ => none
-
-def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
-  | _, _ => none
-
-def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
-  | _, _ => none
-
-def SCHEDULE_GquaddivisorBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def _1ff8f4d {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
-  | C, B1, _Gen0 => do
-    guard C
-    return B1
-
-def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
-  | _, _ => none
-
-def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GexpDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexp_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
-  | _, _ => none
-
-def SCHEDULE_maxCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4294967295
-  | _, _ => none
-
-def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
-  | _, _ => none
-
-def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
-  | _, _ => none
-
-def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
-  | _, _ => none
-
-def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
-  | _, _ => none
-
-def SCHEDULE_GextcodesizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
-  | _, _ => none
-
-def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
-  | _, _ => none
-
-def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
-  | _, _ => none
-
-def SCHEDULE_GfroundDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gfround_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
-  | _, _ => none
-
-def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
-  | _, _ => none
-
-def SCHEDULE_GhighDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ghigh_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
-  | _, _ => none
-
-def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
-  | _, _ => none
-
-def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
-  | _, _ => none
-
-def SCHEDULE_GquaddivisorDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
-  | _, _ => none
-
-def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
-  | _, _ => none
-
-def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
-  | _, _ => none
-
-def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
-  | _, _ => none
-
-def SCHEDULE_GtxdatanonzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 68
-  | _, _ => none
-
-def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
-  | _, _ => none
-
-def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
-  | _, _ => none
-
-def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
-  | _, _ => none
-
-def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
-  | _, _ => none
-
-def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
-  | _, _ => none
-
-def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
-  | _, _ => none
-
-def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
-  | _, _ => none
-
-def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
-  | _, _ => none
-
-def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
-  | _, _ => none
-
-def _61fbef3 : SortBool → SortBool → Option SortBool
-  | false, _Gen0 => some false
-  | _, _ => none
-
-def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
-  | _, _ => none
-
-def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
   | _, _ => none
 
 def SCHEDULE_GtxdatazeroDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gtxdatazero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4
   | _, _ => none
 
-def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
+def SCHEDULE_GcallstipendDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallstipend_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2300
   | _, _ => none
 
-def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+def SCHEDULE_GextcodesizeTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
   | _, _ => none
 
-def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
+def SCHEDULE_GmidDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gmid_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
   | _, _ => none
 
-def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
+def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
   | _, _ => none
 
-def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
+def SCHEDULE_GhighDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ghigh_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
   | _, _ => none
 
-def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GcoldsloadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2100
   | _, _ => none
 
-def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+def SCHEDULE_GlogDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glog_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+  | _, _ => none
+
+def SCHEDULE_GlogtopicDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glogtopic_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+  | _, _ => none
+
+def SCHEDULE_RbMerge : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.MERGE_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GsstoresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20000
   | _, _ => none
 
 def SCHEDULE_GsloadIstanbul : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 800
   | _, _ => none
 
-def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+def SCHEDULE_GpointevalDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
   | _, _ => none
 
-def SCHEDULE_GmemoryDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+def SCHEDULE_GzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GcallDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40
+  | _, _ => none
+
+def SCHEDULE_GjumpdestDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gjumpdest_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 34000
+  | _, _ => none
+
+def SCHEDULE_RselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 24000
   | _, _ => none
 
 def SCHEDULE_RbDefault : SortScheduleConst → SortSchedule → Option SortInt
   | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000000000000000000
+  | _, _ => none
+
+def SCHEDULE_maxCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 4294967295
+  | _, _ => none
+
+def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
+  | _, _ => none
+
+def _53fc758 : SortBool → Option SortBool
+  | true => some false
+  | _ => none
+
+def SCHEDULE_GquaddivisorBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GecpairconstDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 100000
+  | _, _ => none
+
+def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GsloadTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 200
+  | _, _ => none
+
+def _17ebc68 : SortBool → Option SortBool
+  | false => some true
+  | _ => none
+
+def SCHEDULE_GaccessliststoragekeyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GbalanceIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_RselfdestructLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragedirtystoreDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstoragedirtystore_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_RsstoreclearDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rsstoreclear_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 15000
+  | _, _ => none
+
+def SCHEDULE_maxInitCodeSizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxInitCodeSize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GecmulIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 6000
+  | _, _ => none
+
+def SCHEDULE_GcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 32000
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_maxCodeSizeDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.maxCodeSize_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 24576
+  | _, _ => none
+
+def SCHEDULE_Gsha3Default : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 30
+  | _, _ => none
+
+def SCHEDULE_GquaddivisorDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquaddivisor_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def _61fbef3 : SortBool → SortBool → Option SortBool
+  | false, _Gen0 => some false
+  | _, _ => none
+
+def SCHEDULE_GcallTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcall_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDragon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.SPURIOUS_DRAGON_EVM => some 50
+  | _, _ => none
+
+def SCHEDULE_GselfdestructDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _991a329 : SortBool → SortBool → Option SortBool
+  | false, B => some B
+  | _, _ => none
+
+def SCHEDULE_GtransactionDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtransaction_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 21000
+  | _, _ => none
+
+def SCHEDULE_GecaddIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 150
+  | _, _ => none
+
+def SCHEDULE_RmaxquotientDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GexpbyteDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexpbyte_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GaccesslistaddressBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2400
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 700
+  | _, _ => none
+
+def SCHEDULE_GcoldsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def _5b9db8d : SortBool → SortBool → Option SortBool
+  | true, B => some B
+  | _, _ => none
+
+def SCHEDULE_GecpairconstIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpairconst_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 45000
+  | _, _ => none
+
+def SCHEDULE_Gsha3wordDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsha3word_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 6
+  | _, _ => none
+
+def SCHEDULE_GextcodecopyDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodecopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GextcodesizeDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gextcodesize_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GblockhashDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gblockhash_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GtxdatanonzeroIstanbul : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.ISTANBUL_EVM => some 16
   | _, _ => none
 
 def SCHEDULE_GbalanceTangerine : SortScheduleConst → SortSchedule → Option SortInt
@@ -574,103 +245,476 @@ def SCHEDULE_GcoldaccountaccessBerlin : SortScheduleConst → SortSchedule → O
   | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 2600
   | _, _ => none
 
-def SCHEDULE_GtxcreateDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 53000
+def SCHEDULE_RmaxquotientLondon : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rmaxquotient_SCHEDULE_ScheduleConst, SortSchedule.LONDON_EVM => some 5
   | _, _ => none
 
-def SCHEDULE_GcopyDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gcopy_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+def SCHEDULE_GecaddDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecadd_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 500
   | _, _ => none
 
-def SCHEDULE_GnewaccountDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Gnewaccount_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 25000
+def SCHEDULE_GselfdestructTangerine : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gselfdestruct_SCHEDULE_ScheduleConst, SortSchedule.TANGERINE_WHISTLE_EVM => some 5000
   | _, _ => none
 
-def SCHEDULE_GlogtopicDefault : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Glogtopic_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 375
+def SCHEDULE_GaccesslistaddressDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccesslistaddress_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
   | _, _ => none
 
-def _5b9db8d : SortBool → SortBool → Option SortBool
-  | true, B => some B
+def SCHEDULE_GlogdataDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glogdata_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 8
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 100
+  | _, _ => none
+
+def SCHEDULE_GaccessliststoragekeyBerlin : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gaccessliststoragekey_SCHEDULE_ScheduleConst, SortSchedule.BERLIN_EVM => some 1900
+  | _, _ => none
+
+def SCHEDULE_GwarmstoragereadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gwarmstorageread_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GexpDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gexp_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 10
+  | _, _ => none
+
+def SCHEDULE_GfroundDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gfround_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 1
+  | _, _ => none
+
+def SCHEDULE_GtxdatanonzeroDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxdatanonzero_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 68
+  | _, _ => none
+
+def SCHEDULE_GverylowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GcoldaccountaccessDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcoldaccountaccess_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 0
+  | _, _ => none
+
+def SCHEDULE_GlowDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Glow_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5
+  | _, _ => none
+
+def SCHEDULE_GquadcoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 512
+  | _, _ => none
+
+def SCHEDULE_GecmulDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecmul_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 40000
+  | _, _ => none
+
+def SCHEDULE_GmemoryDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 3
+  | _, _ => none
+
+def SCHEDULE_GcallvalueDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcallvalue_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 9000
+  | _, _ => none
+
+def _7174452 : SortBool → SortBool → Option SortBool
+  | true, _Gen0 => some true
+  | _, _ => none
+
+def SCHEDULE_GecpaircoeffDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gecpaircoeff_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 80000
+  | _, _ => none
+
+def SCHEDULE_GbaseDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbase_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GsstoreresetDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 5000
+  | _, _ => none
+
+axiom «_==K_» (x0 : SortK) (x1 : SortK) : Option SortBool
+
+def SCHEDULE_GcodedepositDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gcodedeposit_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 200
+  | _, _ => none
+
+def SCHEDULE_GpointevalCancun : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gpointeval_SCHEDULE_ScheduleConst, SortSchedule.CANCUN_EVM => some 50000
+  | _, _ => none
+
+def SCHEDULE_GbalanceDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gbalance_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 20
+  | _, _ => none
+
+def SCHEDULE_GsloadDefault : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gsload_SCHEDULE_ScheduleConst, SortSchedule.DEFAULT_EVM => some 50
+  | _, _ => none
+
+def SCHEDULE_GinitcodewordcostShanghai : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Ginitcodewordcost_SCHEDULE_ScheduleConst, SortSchedule.SHANGHAI_EVM => some 2
+  | _, _ => none
+
+def SCHEDULE_GtxcreateFrontier : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Gtxcreate_SCHEDULE_ScheduleConst, SortSchedule.FRONTIER_EVM => some 21000
+  | _, _ => none
+
+axiom «Map:lookupOrDefault» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortKItem
+
+def SCHEDULE_GhasbasefeeLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GstaticcalldepthTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasshiftConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrejectedfirstbyteDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhastransientCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasprevrandaoDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasreturndataDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasrevertByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstorePetersburg : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.PETERSBURG_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhassstorestipendIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasaccesslistDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasshiftDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasshift_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GemptyisnonexistentDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaspushzeroDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaschainidDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasbeaconrootCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasbeaconroot_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaschainidIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaschainid_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmaxinitcodesizeShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Constantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GstaticcalldepthDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gstaticcalldepth_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def _1ff8f4d {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
+  | C, B1, _Gen0 => do
+    guard C
+    return B1
+
+def SCHEDULE_GhaswarmcoinbaseShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasblobhashCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrevertDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrevert_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasmcopyDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaswithdrawalsShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswithdrawals_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GselfdestructnewaccountTangerine : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.TANGERINE_WHISTLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmcopyCancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmcopy_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasprevrandaoMerge : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasprevrandao_SCHEDULE_ScheduleFlag, SortSchedule.MERGE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhastransientDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghastransient_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GzerovaluenewaccountgasDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gzerovaluenewaccountgas_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhassstorestipendDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghassstorestipend_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasblobbasefeeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobbasefee_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasselfbalanceIstanbul : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.ISTANBUL_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GemptyisnonexistentDragon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gemptyisnonexistent_SCHEDULE_ScheduleFlag, SortSchedule.SPURIOUS_DRAGON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghaseip6780Cancun : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaseip6780_SCHEDULE_ScheduleFlag, SortSchedule.CANCUN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_hasaccesslistBerlin : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasaccesslist_SCHEDULE_ScheduleFlag, SortSchedule.BERLIN_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhaswarmcoinbaseDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaswarmcoinbase_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GselfdestructnewaccountDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Gselfdestructnewaccount_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasstaticcallByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasrejectedfirstbyteLondon : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasrejectedfirstbyte_SCHEDULE_ScheduleFlag, SortSchedule.LONDON_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_Ghascreate2Default : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghascreate2_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhaspushzeroShanghai : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghaspushzero_SCHEDULE_ScheduleFlag, SortSchedule.SHANGHAI_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasstaticcallDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasstaticcall_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasreturndataByzantium : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasreturndata_SCHEDULE_ScheduleFlag, SortSchedule.BYZANTIUM_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasmaxinitcodesizeDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasmaxinitcodesize_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasselfbalanceDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasselfbalance_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+def SCHEDULE_GhasextcodehashConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasextcodehash_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasdirtysstoreConstantinople : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag, SortSchedule.CONSTANTINOPLE_EVM => some true
+  | _, _ => none
+
+def SCHEDULE_GhasblobhashDefault : SortScheduleFlag → SortSchedule → Option SortBool
+  | SortScheduleFlag.Ghasblobhash_SCHEDULE_ScheduleFlag, SortSchedule.DEFAULT_EVM => some false
+  | _, _ => none
+
+axiom «.Map» : Option SortMap
+
+axiom «Set:in» (x0 : SortKItem) (x1 : SortSet) : Option SortBool
+
+def _432e4e6 : SortSet → SortInt → Option SortBool
+  | _Gen0, _Gen1 => some false
+
+axiom «Map:update» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortMap
+
+def _92664aa : SortK → Option SortBool
+  | SortK.kseq (SortKItem.inj_SortInt Int) SortK.dotk => some true
+  | _ => none
+
+axiom ListItem (x0 : SortKItem) : Option SortList
+
+def _50d266e : SortInt → SortInt → Option SortInt
+  | I1, 1 => some I1
   | _, _ => none
 
 def _5321d80 : SortInt → SortInt → Option SortInt
   | _I1, 0 => some 0
   | _, _ => none
 
-def _50d266e : SortInt → SortInt → Option SortInt
-  | I1, 1 => some I1
-  | _, _ => none
-
-def _432e4e6 : SortSet → SortInt → Option SortBool
-  | _Gen0, _Gen1 => some false
-
-axiom «Set:in» (x0 : SortKItem) (x1 : SortSet) : Option SortBool
-
-axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
-
-def _105572a : SortK → Option SortBool
-  | K => some false
-
-axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
-
-def _92664aa : SortK → Option SortBool
-  | SortK.kseq (SortKItem.inj_SortInt Int) SortK.dotk => some true
-  | _ => none
-
-axiom «_|->_» (x0 : SortKItem) (x1 : SortKItem) : Option SortMap
-
-axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
-
-axiom WithdrawalCellMapItem (x0 : SortWithdrawalIDCell) (x1 : SortWithdrawalCell) : Option SortWithdrawalCellMap
-
-axiom ListItem (x0 : SortKItem) : Option SortList
-
-def _8d90a32 : SortMap → SortAccount → SortInt → Option SortBool
-  | _Gen0, _Gen1, _Gen2 => some false
-
-def _a3e3b07 : SortKItem → SortInt → Option SortBool
-  | _Gen0, _Gen1 => some false
-
-axiom «.Map» : Option SortMap
-
-axiom «Set:difference» (x0 : SortSet) (x1 : SortSet) : Option SortSet
-
-axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
-
 def _75897fa : SortWordStack → SortInt → Option SortInt
   | SortWordStack.«.WordStack_EVM-TYPES_WordStack», SIZE => some SIZE
   | _, _ => none
-
-axiom «Map:update» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortMap
-
-axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
-
-axiom «_in_keys(_)_MAP_Bool_KItem_Map» (x0 : SortKItem) (x1 : SortMap) : Option SortBool
-
-axiom «.AccountCellMap» : Option SortAccountCellMap
-
-axiom «Map:lookupOrDefault» (x0 : SortMap) (x1 : SortKItem) (x2 : SortKItem) : Option SortKItem
-
-axiom «Map:lookup» (x0 : SortMap) (x1 : SortKItem) : Option SortKItem
-
-axiom «.Set» : Option SortSet
-
-axiom _MessageCellMap_ (x0 : SortMessageCellMap) (x1 : SortMessageCellMap) : Option SortMessageCellMap
-
-axiom «.MessageCellMap» : Option SortMessageCellMap
-
-axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
-
-axiom SetItem (x0 : SortKItem) : Option SortSet
 
 def _0e7f507 : SortK → Option SortSet
   | SortK.kseq (SortKItem.inj_SortSet K) SortK.dotk => some K
   | _ => none
 
+axiom «Set:difference» (x0 : SortSet) (x1 : SortSet) : Option SortSet
+
+axiom _Set_ (x0 : SortSet) (x1 : SortSet) : Option SortSet
+
+axiom _AccountCellMap_ (x0 : SortAccountCellMap) (x1 : SortAccountCellMap) : Option SortAccountCellMap
+
+def _8d90a32 : SortMap → SortAccount → SortInt → Option SortBool
+  | _Gen0, _Gen1, _Gen2 => some false
+
+axiom «_|->_» (x0 : SortKItem) (x1 : SortKItem) : Option SortMap
+
+axiom «.AccountCellMap» : Option SortAccountCellMap
+
+axiom «_%Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt
+
+axiom SetItem (x0 : SortKItem) : Option SortSet
+
+def _a3e3b07 : SortKItem → SortInt → Option SortBool
+  | _Gen0, _Gen1 => some false
+
+axiom AccountCellMapItem (x0 : SortAcctIDCell) (x1 : SortAccountCell) : Option SortAccountCellMap
+
+axiom «.MessageCellMap» : Option SortMessageCellMap
+
+axiom _Map_ (x0 : SortMap) (x1 : SortMap) : Option SortMap
+
+axiom «Map:lookup» (x0 : SortMap) (x1 : SortKItem) : Option SortKItem
+
+axiom «_in_keys(_)_MAP_Bool_KItem_Map» (x0 : SortKItem) (x1 : SortMap) : Option SortBool
+
+axiom «_^Int_» (x0 : SortInt) (x1 : SortInt) : Option SortInt
+
+def _105572a : SortK → Option SortBool
+  | K => some false
+
+axiom _List_ (x0 : SortList) (x1 : SortList) : Option SortList
+
+axiom _MessageCellMap_ (x0 : SortMessageCellMap) (x1 : SortMessageCellMap) : Option SortMessageCellMap
+
+axiom _WithdrawalCellMap_ (x0 : SortWithdrawalCellMap) (x1 : SortWithdrawalCellMap) : Option SortWithdrawalCellMap
+
+axiom WithdrawalCellMapItem (x0 : SortWithdrawalIDCell) (x1 : SortWithdrawalCell) : Option SortWithdrawalCellMap
+
+axiom «.Set» : Option SortSet
+
 axiom «.List» : Option SortList
 
 axiom MessageCellMapItem (x0 : SortMsgIDCell) (x1 : SortMessageCell) : Option SortMessageCellMap
+
+axiom «.WithdrawalCellMap» : Option SortWithdrawalCellMap
+
+def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
+
+def _andBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_5b9db8d x0 x1) <|> (_61fbef3 x0 x1)
+
+def SCHEDULE_RbConstantinople : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.CONSTANTINOPLE_EVM => do
+    let _Val0 <- «_*Int_» 2 1000000000000000000
+    return _Val0
+  | _, _ => none
+
+def SCHEDULE_RbByzantium : SortScheduleConst → SortSchedule → Option SortInt
+  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.BYZANTIUM_EVM => do
+    let _Val0 <- «_*Int_» 3 1000000000000000000
+    return _Val0
+  | _, _ => none
+
+def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
+
+def _20f05d9 : SortInt → SortEndianness → SortSignedness → Option SortBytes
+  | I, E, SortSignedness.signedBytes => do
+    let _Val0 <- «_>Int_» I 0
+    let _Val1 <- «log2Int(_)_INT-COMMON_Int_Int» I
+    let _Val2 <- «_+Int_» _Val1 9
+    let _Val3 <- «_/Int_» _Val2 8
+    let _Val4 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val3 I E
+    guard _Val0
+    return _Val4
+  | _, _, _ => none
+
+def _e9743d5 : SortInt → SortEndianness → SortSignedness → Option SortBytes
+  | I, E, SortSignedness.unsignedBytes => do
+    let _Val0 <- «_>Int_» I 0
+    let _Val1 <- «log2Int(_)_INT-COMMON_Int_Int» I
+    let _Val2 <- «_+Int_» _Val1 8
+    let _Val3 <- «_/Int_» _Val2 8
+    let _Val4 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val3 I E
+    guard _Val0
+    return _Val4
+  | _, _, _ => none
 
 def _6c109c0 : SortInt → SortEndianness → SortSignedness → Option SortBytes
   | I, E, SortSignedness.signedBytes => do
@@ -679,6 +723,17 @@ def _6c109c0 : SortInt → SortEndianness → SortSignedness → Option SortByte
     guard _Val0
     return _Val1
   | _, _, _ => none
+
+noncomputable def _42ba953 : SortSet → SortInt → Option SortBool
+  | KEYS, KEY => do
+    let _Val0 <- «Set:in» ((@inj SortInt SortKItem) KEY) KEYS
+    guard _Val0
+    return true
+
+def _524eb33 : SortInt → SortInt → Option SortBytes
+  | _SIZE, _Gen0 => do
+    let _Val0 <- «.Bytes_BYTES-HOOKED_Bytes»
+    return _Val0
 
 def _ea9648a : SortInt → SortEndianness → SortSignedness → Option SortBytes
   | I, _Gen0, _Gen1 => do
@@ -694,44 +749,6 @@ def _a656ca7 : SortBytes → SortInt → SortBytes → Option SortBytes
     guard _Val0
     return _Val1
 
-def _20f05d9 : SortInt → SortEndianness → SortSignedness → Option SortBytes
-  | I, E, SortSignedness.signedBytes => do
-    let _Val0 <- «_>Int_» I 0
-    let _Val1 <- «log2Int(_)_INT-COMMON_Int_Int» I
-    let _Val2 <- «_+Int_» _Val1 9
-    let _Val3 <- «_/Int_» _Val2 8
-    let _Val4 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val3 I E
-    guard _Val0
-    return _Val4
-  | _, _, _ => none
-
-def _43f856e : SortInt → SortEndianness → SortSignedness → Option SortBytes
-  | I, E, SortSignedness.signedBytes => do
-    let _Val0 <- «_<Int_» I (-1)
-    let _Val1 <- «~Int_» I
-    let _Val2 <- «log2Int(_)_INT-COMMON_Int_Int» _Val1
-    let _Val3 <- «_+Int_» _Val2 9
-    let _Val4 <- «_/Int_» _Val3 8
-    let _Val5 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val4 I E
-    guard _Val0
-    return _Val5
-  | _, _, _ => none
-
-def _e9743d5 : SortInt → SortEndianness → SortSignedness → Option SortBytes
-  | I, E, SortSignedness.unsignedBytes => do
-    let _Val0 <- «_>Int_» I 0
-    let _Val1 <- «log2Int(_)_INT-COMMON_Int_Int» I
-    let _Val2 <- «_+Int_» _Val1 8
-    let _Val3 <- «_/Int_» _Val2 8
-    let _Val4 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val3 I E
-    guard _Val0
-    return _Val4
-  | _, _, _ => none
-
-def _orBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_7174452 x0 x1) <|> (_991a329 x0 x1)
-
-def notBool_ (x0 : SortBool) : Option SortBool := (_17ebc68 x0) <|> (_53fc758 x0)
-
 def _e985b28 : SortInt → SortInt → Option SortInt
   | I1, I2 => do
     let _Val0 <- «_<Int_» 1 I2
@@ -741,63 +758,17 @@ def _e985b28 : SortInt → SortInt → Option SortInt
     guard _Val0
     return _Val3
 
-def SCHEDULE_RbConstantinople : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.CONSTANTINOPLE_EVM => do
-    let _Val0 <- «_*Int_» 2 1000000000000000000
-    return _Val0
-  | _, _ => none
-
-def SCHEDULE_RbByzantium : SortScheduleConst → SortSchedule → Option SortInt
-  | SortScheduleConst.Rb_SCHEDULE_ScheduleConst, SortSchedule.BYZANTIUM_EVM => do
-    let _Val0 <- «_*Int_» 3 1000000000000000000
-    return _Val0
-  | _, _ => none
-
-def _andBool_ (x0 : SortBool) (x1 : SortBool) : Option SortBool := (_5b9db8d x0 x1) <|> (_61fbef3 x0 x1)
-
 def _091b7da : SortInt → SortInt → Option SortInt
   | _I1, I2 => do
     let _Val0 <- «_<=Int_» I2 0
     guard _Val0
     return 0
 
-noncomputable def _42ba953 : SortSet → SortInt → Option SortBool
-  | KEYS, KEY => do
-    let _Val0 <- «Set:in» ((@inj SortInt SortKItem) KEY) KEYS
-    guard _Val0
-    return true
-
-def _85aa67b : SortInt → Option SortInt
-  | I => do
-    let _Val0 <- _modInt_ I 115792089237316195423570985008687907853269984665640564039457584007913129639936
-    return _Val0
-
-def _f005287 : SortBytes → SortInt → SortInt → Option SortBytes
-  | _Gen0, _Gen1, WIDTH => do
-    let _Val0 <- «.Bytes_BYTES-HOOKED_Bytes»
-    let _Val1 <- «padRightBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» _Val0 WIDTH 0
-    return _Val1
-
-def isInt (x0 : SortK) : Option SortBool := (_92664aa x0) <|> (_105572a x0)
-
-noncomputable def «EVM_TYPES_#lookup_some» : SortMap → SortInt → Option SortInt
-  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
-    | some ([SortKItem.inj_SortInt VAL], _M) => do
-      let _Val0 <- _modInt_ VAL 115792089237316195423570985008687907853269984665640564039457584007913129639936
-      return _Val0
-    | _ => none
-
 def _ebfe294 : SortInt → SortBytes → Option SortBytes
   | N, BS => do
     let _Val0 <- «_<=Int_» 0 N
     let _Val1 <- «padLeftBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» BS N 0
     guard _Val0
-    return _Val1
-
-noncomputable def _c384edb : SortSet → SortSet → Option SortSet
-  | S1, S2 => do
-    let _Val0 <- «Set:difference» S2 S1
-    let _Val1 <- _Set_ S1 _Val0
     return _Val1
 
 mutual
@@ -813,9 +784,118 @@ end
 
 def «project:Set» (x0 : SortK) : Option SortSet := _0e7f507 x0
 
+def _f005287 : SortBytes → SortInt → SortInt → Option SortBytes
+  | _Gen0, _Gen1, WIDTH => do
+    let _Val0 <- «.Bytes_BYTES-HOOKED_Bytes»
+    let _Val1 <- «padRightBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» _Val0 WIDTH 0
+    return _Val1
+
+noncomputable def _c384edb : SortSet → SortSet → Option SortSet
+  | S1, S2 => do
+    let _Val0 <- «Set:difference» S2 S1
+    let _Val1 <- _Set_ S1 _Val0
+    return _Val1
+
+def _85aa67b : SortInt → Option SortInt
+  | I => do
+    let _Val0 <- _modInt_ I 115792089237316195423570985008687907853269984665640564039457584007913129639936
+    return _Val0
+
+def _43f856e : SortInt → SortEndianness → SortSignedness → Option SortBytes
+  | I, E, SortSignedness.signedBytes => do
+    let _Val0 <- «_<Int_» I (-1)
+    let _Val1 <- «~Int_» I
+    let _Val2 <- «log2Int(_)_INT-COMMON_Int_Int» _Val1
+    let _Val3 <- «_+Int_» _Val2 9
+    let _Val4 <- «_/Int_» _Val3 8
+    let _Val5 <- «Int2Bytes(_,_,_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» _Val4 I E
+    guard _Val0
+    return _Val5
+  | _, _, _ => none
+
+noncomputable def «EVM_TYPES_#lookup_some» : SortMap → SortInt → Option SortInt
+  | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
+    | some ([SortKItem.inj_SortInt VAL], _M) => do
+      let _Val0 <- _modInt_ VAL 115792089237316195423570985008687907853269984665640564039457584007913129639936
+      return _Val0
+    | _ => none
+
+def isInt (x0 : SortK) : Option SortBool := (_92664aa x0) <|> (_105572a x0)
+
+def _2f3f58a {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
+  | C, _Gen0, B2 => do
+    let _Val0 <- notBool_ C
+    guard _Val0
+    return B2
+
+def _4de6e05 : SortInt → SortInt → Option SortBool
+  | I1, I2 => do
+    let _Val0 <- «_==Int_» I1 I2
+    let _Val1 <- notBool_ _Val0
+    return _Val1
+
+def _67678cd : SortInt → SortBytes → Option SortBytes
+  | N, BS => do
+    let _Val0 <- «_<=Int_» 0 N
+    let _Val1 <- notBool_ _Val0
+    guard _Val1
+    return BS
+
+def _8096892 : SortInt → SortInt → SortInt → Option SortInt
+  | MU, _Gen0, WIDTH => do
+    let _Val0 <- «_<Int_» 0 WIDTH
+    let _Val1 <- notBool_ _Val0
+    guard _Val1
+    return MU
+
+noncomputable def «EVM_TYPES_#lookup_none» : SortMap → SortInt → Option SortInt
+  | M, KEY => do
+    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortInt SortKItem) KEY) M
+    let _Val1 <- notBool_ _Val0
+    guard _Val1
+    return 0
+
+noncomputable def _bccaba7 : SortK → SortK → Option SortBool
+  | K1, K2 => do
+    let _Val0 <- «_==K_» K1 K2
+    let _Val1 <- notBool_ _Val0
+    return _Val1
+
+def _ecc9011 : SortBytes → SortInt → SortInt → Option SortBytes
+  | _Gen0, START, WIDTH => do
+    let _Val0 <- «_>=Int_» WIDTH 0
+    let _Val1 <- «_>=Int_» START 0
+    let _Val2 <- _andBool_ _Val0 _Val1
+    let _Val3 <- notBool_ _Val2
+    let _Val4 <- «.Bytes_BYTES-HOOKED_Bytes»
+    guard _Val3
+    return _Val4
+
+def _f03fd7e : SortBytes → SortInt → SortBytes → Option SortBytes
+  | WS, START, WS' => do
+    let _Val0 <- «_<=Int_» 0 START
+    let _Val1 <- «lengthBytes(_)_BYTES-HOOKED_Int_Bytes» WS'
+    let _Val2 <- «_==Int_» _Val1 0
+    let _Val3 <- _andBool_ _Val0 _Val2
+    guard _Val3
+    return WS
+
 -- Necessary to have the following `mutual` block passing without a `decreasing_by` proof
 attribute [local simp] SortScheduleFlag.toNat SortSchedule.toNat
-def Int2BytesNoLen (x0 : SortInt) (x1 : SortEndianness) (x2 : SortSignedness) : Option SortBytes := (_20f05d9 x0 x1 x2) <|> (_43f856e x0 x1 x2) <|> (_6c109c0 x0 x1 x2) <|> (_e9743d5 x0 x1 x2) <|> (_ea9648a x0 x1 x2)
+def EVM_TYPES_bytesRange : SortBytes → SortInt → SortInt → Option SortBytes
+  | WS, START, WIDTH => do
+    let _Val0 <- «_>=Int_» WIDTH 0
+    let _Val1 <- «_>=Int_» START 0
+    let _Val2 <- _andBool_ _Val0 _Val1
+    let _Val3 <- «lengthBytes(_)_BYTES-HOOKED_Int_Bytes» WS
+    let _Val4 <- «_<Int_» START _Val3
+    let _Val5 <- _andBool_ _Val2 _Val4
+    let _Val6 <- «_+Int_» START WIDTH
+    let _Val7 <- «padRightBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» WS _Val6 0
+    let _Val8 <- «_+Int_» START WIDTH
+    let _Val9 <- «substrBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» _Val7 START _Val8
+    guard _Val5
+    return _Val9
 
 mutual
   noncomputable def SCHEDULE_SCHEDFLAGTangerine : SortScheduleFlag → SortSchedule → Option SortBool
@@ -984,84 +1064,15 @@ mutual
     termination_by sc s => (s.toNat, sc.toNat)
 end
 
-def _67678cd : SortInt → SortBytes → Option SortBytes
-  | N, BS => do
-    let _Val0 <- «_<=Int_» 0 N
-    let _Val1 <- notBool_ _Val0
-    guard _Val1
-    return BS
-
-def _8096892 : SortInt → SortInt → SortInt → Option SortInt
-  | MU, _Gen0, WIDTH => do
-    let _Val0 <- «_<Int_» 0 WIDTH
-    let _Val1 <- notBool_ _Val0
-    guard _Val1
-    return MU
-
-def _2f3f58a {SortSort : Type} : SortBool → SortSort → SortSort → Option SortSort
-  | C, _Gen0, B2 => do
-    let _Val0 <- notBool_ C
-    guard _Val0
-    return B2
-
-def _4de6e05 : SortInt → SortInt → Option SortBool
-  | I1, I2 => do
-    let _Val0 <- «_==Int_» I1 I2
-    let _Val1 <- notBool_ _Val0
-    return _Val1
-
-noncomputable def «EVM_TYPES_#lookup_none» : SortMap → SortInt → Option SortInt
-  | M, KEY => do
-    let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortInt SortKItem) KEY) M
-    let _Val1 <- notBool_ _Val0
-    guard _Val1
-    return 0
-
-noncomputable def _bccaba7 : SortK → SortK → Option SortBool
-  | K1, K2 => do
-    let _Val0 <- «_==K_» K1 K2
-    let _Val1 <- notBool_ _Val0
-    return _Val1
-
-def EVM_TYPES_bytesRange : SortBytes → SortInt → SortInt → Option SortBytes
-  | WS, START, WIDTH => do
-    let _Val0 <- «_>=Int_» WIDTH 0
-    let _Val1 <- «_>=Int_» START 0
-    let _Val2 <- _andBool_ _Val0 _Val1
-    let _Val3 <- «lengthBytes(_)_BYTES-HOOKED_Int_Bytes» WS
-    let _Val4 <- «_<Int_» START _Val3
-    let _Val5 <- _andBool_ _Val2 _Val4
-    let _Val6 <- «_+Int_» START WIDTH
-    let _Val7 <- «padRightBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» WS _Val6 0
-    let _Val8 <- «_+Int_» START WIDTH
-    let _Val9 <- «substrBytes(_,_,_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» _Val7 START _Val8
-    guard _Val5
-    return _Val9
-
-def _ecc9011 : SortBytes → SortInt → SortInt → Option SortBytes
-  | _Gen0, START, WIDTH => do
-    let _Val0 <- «_>=Int_» WIDTH 0
-    let _Val1 <- «_>=Int_» START 0
-    let _Val2 <- _andBool_ _Val0 _Val1
-    let _Val3 <- notBool_ _Val2
-    let _Val4 <- «.Bytes_BYTES-HOOKED_Bytes»
-    guard _Val3
-    return _Val4
-
-def _f03fd7e : SortBytes → SortInt → SortBytes → Option SortBytes
-  | WS, START, WS' => do
-    let _Val0 <- «_<=Int_» 0 START
-    let _Val1 <- «lengthBytes(_)_BYTES-HOOKED_Int_Bytes» WS'
-    let _Val2 <- «_==Int_» _Val1 0
-    let _Val3 <- _andBool_ _Val0 _Val2
-    guard _Val3
-    return WS
+noncomputable def «#inStorageAux2» (x0 : SortSet) (x1 : SortInt) : Option SortBool := (_42ba953 x0 x1) <|> (_432e4e6 x0 x1)
 
 def «_up/Int__EVM-TYPES_Int_Int_Int» (x0 : SortInt) (x1 : SortInt) : Option SortInt := (_091b7da x0 x1) <|> (_50d266e x0 x1) <|> (_5321d80 x0 x1) <|> (_e985b28 x0 x1)
 
-noncomputable def «#inStorageAux2» (x0 : SortSet) (x1 : SortInt) : Option SortBool := (_42ba953 x0 x1) <|> (_432e4e6 x0 x1)
+noncomputable def «_|Set__SET_Set_Set_Set» (x0 : SortSet) (x1 : SortSet) : Option SortSet := _c384edb x0 x1
 
 def chop (x0 : SortInt) : Option SortInt := _85aa67b x0
+
+def Int2BytesNoLen (x0 : SortInt) (x1 : SortEndianness) (x2 : SortSignedness) : Option SortBytes := (_20f05d9 x0 x1 x2) <|> (_43f856e x0 x1 x2) <|> (_6c109c0 x0 x1 x2) <|> (_e9743d5 x0 x1 x2) <|> (_ea9648a x0 x1 x2)
 
 noncomputable def «EVM_TYPES_#lookup_notInt» : SortMap → SortInt → Option SortInt
   | _Pat0, KEY => match (MapHook SortKItem SortKItem).split _Pat0.coll [SortKItem.inj_SortInt KEY] with
@@ -1072,18 +1083,11 @@ noncomputable def «EVM_TYPES_#lookup_notInt» : SortMap → SortInt → Option 
       return 0
     | _ => none
 
-noncomputable def «_|Set__SET_Set_Set_Set» (x0 : SortSet) (x1 : SortSet) : Option SortSet := _c384edb x0 x1
-
-def _fdd6ce1 : SortInt → Option SortBytes
-  | W => do
-    let _Val0 <- Int2BytesNoLen W SortEndianness.bigEndianBytes SortSignedness.unsignedBytes
-    return _Val0
-
-def «#padToWidth» (x0 : SortInt) (x1 : SortBytes) : Option SortBytes := (_67678cd x0 x1) <|> (_ebfe294 x0 x1)
-
 def kite {SortSort : Type} (x0 : SortBool) (x1 : SortSort) (x2 : SortSort) : Option SortSort := (_1ff8f4d x0 x1 x2) <|> (_2f3f58a x0 x1 x2)
 
 def «_=/=Int_» (x0 : SortInt) (x1 : SortInt) : Option SortBool := _4de6e05 x0 x1
+
+def «#padToWidth» (x0 : SortInt) (x1 : SortBytes) : Option SortBytes := (_67678cd x0 x1) <|> (_ebfe294 x0 x1)
 
 noncomputable def «_=/=K_» (x0 : SortK) (x1 : SortK) : Option SortBool := _bccaba7 x0 x1
 
@@ -1091,6 +1095,12 @@ def «#range» (x0 : SortBytes) (x1 : SortInt) (x2 : SortInt) : Option SortBytes
 
 -- Necessary to have the following `mutual` block passing without a `decreasing_by` proof
 attribute [local simp] SortScheduleConst.toNat
+noncomputable def _c44ca69 : SortKItem → SortInt → Option SortBool
+  | SortKItem.inj_SortSet KEYS, KEY => do
+    let _Val0 <- «#inStorageAux2» KEYS KEY
+    return _Val0
+  | _, _ => none
+
 def _86ca6df : SortInt → SortInt → SortInt → Option SortInt
   | MU, START, WIDTH => do
     let _Val0 <- «_<Int_» 0 WIDTH
@@ -1100,21 +1110,18 @@ def _86ca6df : SortInt → SortInt → SortInt → Option SortInt
     guard _Val0
     return _Val3
 
-noncomputable def _c44ca69 : SortKItem → SortInt → Option SortBool
-  | SortKItem.inj_SortSet KEYS, KEY => do
-    let _Val0 <- «#inStorageAux2» KEYS KEY
-    return _Val0
-  | _, _ => none
-
 def _ef5332a : SortBytes → Option SortInt
   | WS => do
     let _Val0 <- «Bytes2Int(_,_,_)_BYTES-HOOKED_Int_Bytes_Endianness_Signedness» WS SortEndianness.bigEndianBytes SortSignedness.unsignedBytes
     let _Val1 <- chop _Val0
     return _Val1
 
-noncomputable def lookup (x0 : SortMap) (x1 : SortInt) : Option SortInt := («EVM_TYPES_#lookup_none» x0 x1) <|> («EVM_TYPES_#lookup_notInt» x0 x1) <|> («EVM_TYPES_#lookup_some» x0 x1)
+def _fdd6ce1 : SortInt → Option SortBytes
+  | W => do
+    let _Val0 <- Int2BytesNoLen W SortEndianness.bigEndianBytes SortSignedness.unsignedBytes
+    return _Val0
 
-def «#asByteStack» (x0 : SortInt) : Option SortBytes := _fdd6ce1 x0
+noncomputable def lookup (x0 : SortMap) (x1 : SortInt) : Option SortInt := («EVM_TYPES_#lookup_none» x0 x1) <|> («EVM_TYPES_#lookup_notInt» x0 x1) <|> («EVM_TYPES_#lookup_some» x0 x1)
 
 def _8391694 : SortBytes → SortInt → SortBytes → Option SortBytes
   | WS, START, WS' => do
@@ -1341,13 +1348,28 @@ mutual
   termination_by sc s => (s.toNat, sc.toNat)
 end
 
-def «#memoryUsageUpdate» (x0 : SortInt) (x1 : SortInt) (x2 : SortInt) : Option SortInt := (_8096892 x0 x1 x2) <|> (_86ca6df x0 x1 x2)
-
 noncomputable def «#inStorageAux1» (x0 : SortKItem) (x1 : SortInt) : Option SortBool := (_c44ca69 x0 x1) <|> (_a3e3b07 x0 x1)
+
+def «#memoryUsageUpdate» (x0 : SortInt) (x1 : SortInt) (x2 : SortInt) : Option SortInt := (_8096892 x0 x1 x2) <|> (_86ca6df x0 x1 x2)
 
 def asWord (x0 : SortBytes) : Option SortInt := _ef5332a x0
 
+def «#asByteStack» (x0 : SortInt) : Option SortBytes := _fdd6ce1 x0
+
 def mapWriteRange (x0 : SortBytes) (x1 : SortInt) (x2 : SortBytes) : Option SortBytes := (_8391694 x0 x1 x2) <|> (_a656ca7 x0 x1 x2) <|> (_f03fd7e x0 x1 x2)
+
+noncomputable def GAS_FEES_Csstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, _ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- notBool_ _Val0
+    let _Val2 <- «_==Int_» CURR 0
+    let _Val3 <- «_=/=Int_» NEW 0
+    let _Val4 <- _andBool_ _Val2 _Val3
+    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- kite _Val4 _Val5 _Val6
+    guard _Val1
+    return _Val7
 
 noncomputable def GAS_FEES_Rsstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
   | SCHED, NEW, CURR, _ORIG => do
@@ -1360,6 +1382,31 @@ noncomputable def GAS_FEES_Rsstore_old : SortSchedule → SortInt → SortInt �
     let _Val6 <- kite _Val4 _Val5 0
     guard _Val1
     return _Val6
+
+noncomputable def GAS_FEES_Csstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
+  | SCHED, NEW, CURR, ORIG => do
+    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
+    let _Val1 <- «_==Int_» CURR NEW
+    let _Val2 <- «_=/=Int_» ORIG CURR
+    let _Val3 <- _orBool_ _Val1 _Val2
+    let _Val4 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
+    let _Val5 <- «_==Int_» ORIG 0
+    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
+    let _Val7 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
+    let _Val8 <- kite _Val5 _Val6 _Val7
+    let _Val9 <- kite _Val3 _Val4 _Val8
+    guard _Val0
+    return _Val9
+
+noncomputable def GAS_FEES_Cmem : SortSchedule → SortInt → Option SortInt
+  | SCHED, N => do
+    let _Val0 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst SCHED
+    let _Val1 <- «_*Int_» N _Val0
+    let _Val2 <- «_*Int_» N N
+    let _Val3 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst SCHED
+    let _Val4 <- «_/Int_» _Val2 _Val3
+    let _Val5 <- «_+Int_» _Val1 _Val4
+    return _Val5
 
 noncomputable def GAS_FEES_Rsstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
   | SCHED, NEW, CURR, ORIG => do
@@ -1398,44 +1445,6 @@ noncomputable def GAS_FEES_Rsstore_new : SortSchedule → SortInt → SortInt �
     guard _Val0
     return _Val31
 
-noncomputable def GAS_FEES_Csstore_new : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
-  | SCHED, NEW, CURR, ORIG => do
-    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
-    let _Val1 <- «_==Int_» CURR NEW
-    let _Val2 <- «_=/=Int_» ORIG CURR
-    let _Val3 <- _orBool_ _Val1 _Val2
-    let _Val4 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsload_SCHEDULE_ScheduleConst SCHED
-    let _Val5 <- «_==Int_» ORIG 0
-    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
-    let _Val7 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
-    let _Val8 <- kite _Val5 _Val6 _Val7
-    let _Val9 <- kite _Val3 _Val4 _Val8
-    guard _Val0
-    return _Val9
-
-noncomputable def GAS_FEES_Cmem : SortSchedule → SortInt → Option SortInt
-  | SCHED, N => do
-    let _Val0 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gmemory_SCHEDULE_ScheduleConst SCHED
-    let _Val1 <- «_*Int_» N _Val0
-    let _Val2 <- «_*Int_» N N
-    let _Val3 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gquadcoeff_SCHEDULE_ScheduleConst SCHED
-    let _Val4 <- «_/Int_» _Val2 _Val3
-    let _Val5 <- «_+Int_» _Val1 _Val4
-    return _Val5
-
-noncomputable def GAS_FEES_Csstore_old : SortSchedule → SortInt → SortInt → SortInt → Option SortInt
-  | SCHED, NEW, CURR, _ORIG => do
-    let _Val0 <- «_<<_>>_SCHEDULE_Bool_ScheduleFlag_Schedule» SortScheduleFlag.Ghasdirtysstore_SCHEDULE_ScheduleFlag SCHED
-    let _Val1 <- notBool_ _Val0
-    let _Val2 <- «_==Int_» CURR 0
-    let _Val3 <- «_=/=Int_» NEW 0
-    let _Val4 <- _andBool_ _Val2 _Val3
-    let _Val5 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstoreset_SCHEDULE_ScheduleConst SCHED
-    let _Val6 <- «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gsstorereset_SCHEDULE_ScheduleConst SCHED
-    let _Val7 <- kite _Val4 _Val5 _Val6
-    guard _Val1
-    return _Val7
-
 noncomputable def _dbb1f9e : SortMap → SortAccount → SortInt → Option SortBool
   | TS, ACCT, KEY => do
     let _Val0 <- «_in_keys(_)_MAP_Bool_KItem_Map» ((@inj SortAccount SortKItem) ACCT) TS
@@ -1444,10 +1453,23 @@ noncomputable def _dbb1f9e : SortMap → SortAccount → SortInt → Option Sort
     guard _Val0
     return _Val2
 
-noncomputable def Rsstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Rsstore_new x0 x1 x2 x3) <|> (GAS_FEES_Rsstore_old x0 x1 x2 x3)
-
-noncomputable def Cmem (x0 : SortSchedule) (x1 : SortInt) : Option SortInt := GAS_FEES_Cmem x0 x1
+noncomputable def _23563a4 : SortInt → SortInt → Option SortBytes
+  | SIZE, DATA => do
+    let _Val0 <- «_<Int_» 0 SIZE
+    let _Val1 <- «_*Int_» 8 SIZE
+    let _Val2 <- «_^Int_» 2 _Val1
+    let _Val3 <- «_%Int_» DATA _Val2
+    let _Val4 <- «#asByteStack» _Val3
+    let _Val5 <- «#padToWidth» SIZE _Val4
+    guard _Val0
+    return _Val5
 
 noncomputable def Csstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Csstore_new x0 x1 x2 x3) <|> (GAS_FEES_Csstore_old x0 x1 x2 x3)
 
+noncomputable def Cmem (x0 : SortSchedule) (x1 : SortInt) : Option SortInt := GAS_FEES_Cmem x0 x1
+
+noncomputable def Rsstore (x0 : SortSchedule) (x1 : SortInt) (x2 : SortInt) (x3 : SortInt) : Option SortInt := (GAS_FEES_Rsstore_new x0 x1 x2 x3) <|> (GAS_FEES_Rsstore_old x0 x1 x2 x3)
+
 noncomputable def «#inStorage» (x0 : SortMap) (x1 : SortAccount) (x2 : SortInt) : Option SortBool := (_dbb1f9e x0 x1 x2) <|> (_8d90a32 x0 x1 x2)
+
+noncomputable def buf (x0 : SortInt) (x1 : SortInt) : Option SortBytes := (_23563a4 x0 x1) <|> (_524eb33 x0 x1)

--- a/EvmEquivalence/KEVM2Lean/Inj.lean
+++ b/EvmEquivalence/KEVM2Lean/Inj.lean
@@ -1,261 +1,9 @@
 import EvmEquivalence.KEVM2Lean.Sorts
 
-instance : Inj SortAccountCellMap SortKItem where
-  inj := SortKItem.inj_SortAccountCellMap
+instance : Inj SortMixHashCell SortKItem where
+  inj := SortKItem.inj_SortMixHashCell
   retr
-    | SortKItem.inj_SortAccountCellMap x => some x
-    | _ => none
-
-instance : Inj SortModeCell SortKItem where
-  inj := SortKItem.inj_SortModeCell
-  retr
-    | SortKItem.inj_SortModeCell x => some x
-    | _ => none
-
-instance : Inj SortBlockNonceCell SortKItem where
-  inj := SortKItem.inj_SortBlockNonceCell
-  retr
-    | SortKItem.inj_SortBlockNonceCell x => some x
-    | _ => none
-
-instance : Inj SortCallValueCell SortKItem where
-  inj := SortKItem.inj_SortCallValueCell
-  retr
-    | SortKItem.inj_SortCallValueCell x => some x
-    | _ => none
-
-instance : Inj SortBlobGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortBlobGasUsedCell
-  retr
-    | SortKItem.inj_SortBlobGasUsedCell x => some x
-    | _ => none
-
-instance : Inj SortKCell SortKItem where
-  inj := SortKItem.inj_SortKCell
-  retr
-    | SortKItem.inj_SortKCell x => some x
-    | _ => none
-
-instance : Inj SortMessageCell SortKItem where
-  inj := SortKItem.inj_SortMessageCell
-  retr
-    | SortKItem.inj_SortMessageCell x => some x
-    | _ => none
-
-instance : Inj SortBalanceCell SortKItem where
-  inj := SortKItem.inj_SortBalanceCell
-  retr
-    | SortKItem.inj_SortBalanceCell x => some x
-    | _ => none
-
-instance : Inj SortTxAccessCell SortKItem where
-  inj := SortKItem.inj_SortTxAccessCell
-  retr
-    | SortKItem.inj_SortTxAccessCell x => some x
-    | _ => none
-
-instance : Inj SortCodeCell SortKItem where
-  inj := SortKItem.inj_SortCodeCell
-  retr
-    | SortKItem.inj_SortCodeCell x => some x
-    | _ => none
-
-instance : Inj SortChainIDCell SortKItem where
-  inj := SortKItem.inj_SortChainIDCell
-  retr
-    | SortKItem.inj_SortChainIDCell x => some x
-    | _ => none
-
-instance : Inj SortNonceCell SortKItem where
-  inj := SortKItem.inj_SortNonceCell
-  retr
-    | SortKItem.inj_SortNonceCell x => some x
-    | _ => none
-
-instance : Inj SortKevmCell SortKItem where
-  inj := SortKItem.inj_SortKevmCell
-  retr
-    | SortKItem.inj_SortKevmCell x => some x
-    | _ => none
-
-instance : Inj SortMessageCellMap SortKItem where
-  inj := SortKItem.inj_SortMessageCellMap
-  retr
-    | SortKItem.inj_SortMessageCellMap x => some x
-    | _ => none
-
-instance : Inj SortTransientStorageCell SortKItem where
-  inj := SortKItem.inj_SortTransientStorageCell
-  retr
-    | SortKItem.inj_SortTransientStorageCell x => some x
-    | _ => none
-
-instance : Inj SortSet SortKItem where
-  inj := SortKItem.inj_SortSet
-  retr
-    | SortKItem.inj_SortSet x => some x
-    | _ => none
-
-instance : Inj SortRefundCell SortKItem where
-  inj := SortKItem.inj_SortRefundCell
-  retr
-    | SortKItem.inj_SortRefundCell x => some x
-    | _ => none
-
-instance : Inj SortSigSCell SortKItem where
-  inj := SortKItem.inj_SortSigSCell
-  retr
-    | SortKItem.inj_SortSigSCell x => some x
-    | _ => none
-
-instance : Inj SortPushOp SortKItem where
-  inj := SortKItem.inj_SortPushOp
-  retr
-    | SortKItem.inj_SortPushOp x => some x
-    | _ => none
-
-instance : Inj SortBool SortKItem where
-  inj := SortKItem.inj_SortBool
-  retr
-    | SortKItem.inj_SortBool x => some x
-    | _ => none
-
-instance : Inj SortSigRCell SortKItem where
-  inj := SortKItem.inj_SortSigRCell
-  retr
-    | SortKItem.inj_SortSigRCell x => some x
-    | _ => none
-
-instance : Inj SortInt SortKItem where
-  inj := SortKItem.inj_SortInt
-  retr
-    | SortKItem.inj_SortInt x => some x
-    | _ => none
-
-instance : Inj SortBaseFeeCell SortKItem where
-  inj := SortKItem.inj_SortBaseFeeCell
-  retr
-    | SortKItem.inj_SortBaseFeeCell x => some x
-    | _ => none
-
-instance : Inj SortDifficultyCell SortKItem where
-  inj := SortKItem.inj_SortDifficultyCell
-  retr
-    | SortKItem.inj_SortDifficultyCell x => some x
-    | _ => none
-
-instance : Inj SortCallerCell SortKItem where
-  inj := SortKItem.inj_SortCallerCell
-  retr
-    | SortKItem.inj_SortCallerCell x => some x
-    | _ => none
-
-instance : Inj SortExitCodeCell SortKItem where
-  inj := SortKItem.inj_SortExitCodeCell
-  retr
-    | SortKItem.inj_SortExitCodeCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleConst SortKItem where
-  inj := SortKItem.inj_SortScheduleConst
-  retr
-    | SortKItem.inj_SortScheduleConst x => some x
-    | _ => none
-
-instance : Inj SortCallStackCell SortKItem where
-  inj := SortKItem.inj_SortCallStackCell
-  retr
-    | SortKItem.inj_SortCallStackCell x => some x
-    | _ => none
-
-instance : Inj SortBlockCell SortKItem where
-  inj := SortKItem.inj_SortBlockCell
-  retr
-    | SortKItem.inj_SortBlockCell x => some x
-    | _ => none
-
-instance : Inj SortStatusCodeCell SortKItem where
-  inj := SortKItem.inj_SortStatusCodeCell
-  retr
-    | SortKItem.inj_SortStatusCodeCell x => some x
-    | _ => none
-
-instance : Inj SortSigVCell SortKItem where
-  inj := SortKItem.inj_SortSigVCell
-  retr
-    | SortKItem.inj_SortSigVCell x => some x
-    | _ => none
-
-instance : Inj SortAmountCell SortKItem where
-  inj := SortKItem.inj_SortAmountCell
-  retr
-    | SortKItem.inj_SortAmountCell x => some x
-    | _ => none
-
-instance : Inj SortTxOrderCell SortKItem where
-  inj := SortKItem.inj_SortTxOrderCell
-  retr
-    | SortKItem.inj_SortTxOrderCell x => some x
-    | _ => none
-
-instance : Inj SortTxNonceCell SortKItem where
-  inj := SortKItem.inj_SortTxNonceCell
-  retr
-    | SortKItem.inj_SortTxNonceCell x => some x
-    | _ => none
-
-instance : Inj SortTxMaxBlobFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxBlobFeeCell
-  retr
-    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
-    | _ => none
-
-instance : Inj SortTxVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortTxVersionedHashesCell
-  retr
-    | SortKItem.inj_SortTxVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalIDCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalIDCell
-  retr
-    | SortKItem.inj_SortWithdrawalIDCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleCell SortKItem where
-  inj := SortKItem.inj_SortScheduleCell
-  retr
-    | SortKItem.inj_SortScheduleCell x => some x
-    | _ => none
-
-instance : Inj SortProgramCell SortKItem where
-  inj := SortKItem.inj_SortProgramCell
-  retr
-    | SortKItem.inj_SortProgramCell x => some x
-    | _ => none
-
-instance : Inj SortAcctIDCell SortKItem where
-  inj := SortKItem.inj_SortAcctIDCell
-  retr
-    | SortKItem.inj_SortAcctIDCell x => some x
-    | _ => none
-
-instance : Inj SortGasUsedCell SortKItem where
-  inj := SortKItem.inj_SortGasUsedCell
-  retr
-    | SortKItem.inj_SortGasUsedCell x => some x
-    | _ => none
-
-instance : Inj SortJumpDestsCell SortKItem where
-  inj := SortKItem.inj_SortJumpDestsCell
-  retr
-    | SortKItem.inj_SortJumpDestsCell x => some x
-    | _ => none
-
-instance : Inj SortCallDepthCell SortKItem where
-  inj := SortKItem.inj_SortCallDepthCell
-  retr
-    | SortKItem.inj_SortCallDepthCell x => some x
+    | SortKItem.inj_SortMixHashCell x => some x
     | _ => none
 
 instance : Inj SortLogsBloomCell SortKItem where
@@ -264,131 +12,16 @@ instance : Inj SortLogsBloomCell SortKItem where
     | SortKItem.inj_SortLogsBloomCell x => some x
     | _ => none
 
-instance : Inj SortGeneratedTopCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedTopCell
+instance : Inj SortList SortKItem where
+  inj := SortKItem.inj_SortList
   retr
-    | SortKItem.inj_SortGeneratedTopCell x => some x
+    | SortKItem.inj_SortList x => some x
     | _ => none
 
-instance : Inj SortTxPriorityFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxPriorityFeeCell
+instance : Inj SortTxOrderCell SortKItem where
+  inj := SortKItem.inj_SortTxOrderCell
   retr
-    | SortKItem.inj_SortTxPriorityFeeCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCell SortKItem where
-  inj := SortKItem.inj_SortAccountCell
-  retr
-    | SortKItem.inj_SortAccountCell x => some x
-    | _ => none
-
-instance : Inj SortOutputCell SortKItem where
-  inj := SortKItem.inj_SortOutputCell
-  retr
-    | SortKItem.inj_SortOutputCell x => some x
-    | _ => none
-
-instance : Inj SortWordStackCell SortKItem where
-  inj := SortKItem.inj_SortWordStackCell
-  retr
-    | SortKItem.inj_SortWordStackCell x => some x
-    | _ => none
-
-instance : Inj SortOmmerBlockHeadersCell SortKItem where
-  inj := SortKItem.inj_SortOmmerBlockHeadersCell
-  retr
-    | SortKItem.inj_SortOmmerBlockHeadersCell x => some x
-    | _ => none
-
-instance : Inj SortMsgIDCell SortKItem where
-  inj := SortKItem.inj_SortMsgIDCell
-  retr
-    | SortKItem.inj_SortMsgIDCell x => some x
-    | _ => none
-
-instance : Inj SortCallStateCell SortKItem where
-  inj := SortKItem.inj_SortCallStateCell
-  retr
-    | SortKItem.inj_SortCallStateCell x => some x
-    | _ => none
-
-instance : Inj SortCallGasCell SortKItem where
-  inj := SortKItem.inj_SortCallGasCell
-  retr
-    | SortKItem.inj_SortCallGasCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsOrderCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsOrderCell
-  retr
-    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
-    | _ => none
-
-instance : Inj SortBeaconRootCell SortKItem where
-  inj := SortKItem.inj_SortBeaconRootCell
-  retr
-    | SortKItem.inj_SortBeaconRootCell x => some x
-    | _ => none
-
-instance : Inj SortUseGasCell SortKItem where
-  inj := SortKItem.inj_SortUseGasCell
-  retr
-    | SortKItem.inj_SortUseGasCell x => some x
-    | _ => none
-
-instance : Inj SortAccount SortKItem where
-  inj
-    | SortAccount.inj_SortInt x => SortKItem.inj_SortInt x
-    | x => SortKItem.inj_SortAccount x
-  retr
-    | SortKItem.inj_SortInt x => some (SortAccount.inj_SortInt x)
-    | SortKItem.inj_SortAccount x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalCell
-  retr
-    | SortKItem.inj_SortWithdrawalCell x => some x
-    | _ => none
-
-instance : Inj SortGas SortKItem where
-  inj
-    | SortGas.inj_SortInt x => SortKItem.inj_SortInt x
-  retr
-    | SortKItem.inj_SortInt x => some (SortGas.inj_SortInt x)
-    | SortKItem.inj_SortGas x => some x
-    | _ => none
-
-instance : Inj SortTxGasLimitCell SortKItem where
-  inj := SortKItem.inj_SortTxGasLimitCell
-  retr
-    | SortKItem.inj_SortTxGasLimitCell x => some x
-    | _ => none
-
-instance : Inj SortMaybeOpCode SortKItem where
-  inj
-    | SortMaybeOpCode.inj_SortBinStackOp x => SortKItem.inj_SortBinStackOp x
-    | SortMaybeOpCode.inj_SortInternalOp x => SortKItem.inj_SortInternalOp x
-    | SortMaybeOpCode.inj_SortPushOp x => SortKItem.inj_SortPushOp x
-    | SortMaybeOpCode.inj_SortUnStackOp x => SortKItem.inj_SortUnStackOp x
-  retr
-    | SortKItem.inj_SortBinStackOp x => some (SortMaybeOpCode.inj_SortBinStackOp x)
-    | SortKItem.inj_SortInternalOp x => some (SortMaybeOpCode.inj_SortInternalOp x)
-    | SortKItem.inj_SortPushOp x => some (SortMaybeOpCode.inj_SortPushOp x)
-    | SortKItem.inj_SortUnStackOp x => some (SortMaybeOpCode.inj_SortUnStackOp x)
-    | SortKItem.inj_SortMaybeOpCode x => some x
-    | _ => none
-
-instance : Inj SortCreatedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortCreatedAccountsCell
-  retr
-    | SortKItem.inj_SortCreatedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortToCell SortKItem where
-  inj := SortKItem.inj_SortToCell
-  retr
-    | SortKItem.inj_SortToCell x => some x
+    | SortKItem.inj_SortTxOrderCell x => some x
     | _ => none
 
 instance : Inj SortAccountsCell SortKItem where
@@ -397,344 +30,28 @@ instance : Inj SortAccountsCell SortKItem where
     | SortKItem.inj_SortAccountsCell x => some x
     | _ => none
 
-instance : Inj SortPcCell SortKItem where
-  inj := SortKItem.inj_SortPcCell
+instance : Inj SortUseGasCell SortKItem where
+  inj := SortKItem.inj_SortUseGasCell
   retr
-    | SortKItem.inj_SortPcCell x => some x
+    | SortKItem.inj_SortUseGasCell x => some x
     | _ => none
 
-instance : Inj SortSchedule SortKItem where
-  inj := SortKItem.inj_SortSchedule
+instance : Inj SortStatusCodeCell SortKItem where
+  inj := SortKItem.inj_SortStatusCodeCell
   retr
-    | SortKItem.inj_SortSchedule x => some x
+    | SortKItem.inj_SortStatusCodeCell x => some x
     | _ => none
 
-instance : Inj SortEndianness SortKItem where
-  inj := SortKItem.inj_SortEndianness
+instance : Inj SortWithdrawalCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalCell
   retr
-    | SortKItem.inj_SortEndianness x => some x
+    | SortKItem.inj_SortWithdrawalCell x => some x
     | _ => none
 
-instance : Inj SortGasCell SortKItem where
-  inj := SortKItem.inj_SortGasCell
+instance : Inj SortOutputCell SortKItem where
+  inj := SortKItem.inj_SortOutputCell
   retr
-    | SortKItem.inj_SortGasCell x => some x
-    | _ => none
-
-instance : Inj SortTxGasPriceCell SortKItem where
-  inj := SortKItem.inj_SortTxGasPriceCell
-  retr
-    | SortKItem.inj_SortTxGasPriceCell x => some x
-    | _ => none
-
-instance : Inj SortExtraDataCell SortKItem where
-  inj := SortKItem.inj_SortExtraDataCell
-  retr
-    | SortKItem.inj_SortExtraDataCell x => some x
-    | _ => none
-
-instance : Inj SortValidatorIndexCell SortKItem where
-  inj := SortKItem.inj_SortValidatorIndexCell
-  retr
-    | SortKItem.inj_SortValidatorIndexCell x => some x
-    | _ => none
-
-instance : Inj SortMode SortKItem where
-  inj := SortKItem.inj_SortMode
-  retr
-    | SortKItem.inj_SortMode x => some x
-    | _ => none
-
-instance : Inj SortLocalMemCell SortKItem where
-  inj := SortKItem.inj_SortLocalMemCell
-  retr
-    | SortKItem.inj_SortLocalMemCell x => some x
-    | _ => none
-
-instance : Inj SortAccountCode SortKItem where
-  inj
-    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
-  retr
-    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
-    | SortKItem.inj_SortAccountCode x => some x
-    | _ => none
-
-instance : Inj SortEvmCell SortKItem where
-  inj := SortKItem.inj_SortEvmCell
-  retr
-    | SortKItem.inj_SortEvmCell x => some x
-    | _ => none
-
-instance : Inj SortMessagesCell SortKItem where
-  inj := SortKItem.inj_SortMessagesCell
-  retr
-    | SortKItem.inj_SortMessagesCell x => some x
-    | _ => none
-
-instance : Inj SortBinStackOp SortKItem where
-  inj := SortKItem.inj_SortBinStackOp
-  retr
-    | SortKItem.inj_SortBinStackOp x => some x
-    | _ => none
-
-instance : Inj SortList SortKItem where
-  inj := SortKItem.inj_SortList
-  retr
-    | SortKItem.inj_SortList x => some x
-    | _ => none
-
-instance : Inj SortStaticCell SortKItem where
-  inj := SortKItem.inj_SortStaticCell
-  retr
-    | SortKItem.inj_SortStaticCell x => some x
-    | _ => none
-
-instance : Inj SortReceiptsRootCell SortKItem where
-  inj := SortKItem.inj_SortReceiptsRootCell
-  retr
-    | SortKItem.inj_SortReceiptsRootCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalCellMap SortKItem where
-  inj := SortKItem.inj_SortWithdrawalCellMap
-  retr
-    | SortKItem.inj_SortWithdrawalCellMap x => some x
-    | _ => none
-
-instance : Inj SortIndexCell SortKItem where
-  inj := SortKItem.inj_SortIndexCell
-  retr
-    | SortKItem.inj_SortIndexCell x => some x
-    | _ => none
-
-instance : Inj SortValueCell SortKItem where
-  inj := SortKItem.inj_SortValueCell
-  retr
-    | SortKItem.inj_SortValueCell x => some x
-    | _ => none
-
-instance : Inj SortNetworkCell SortKItem where
-  inj := SortKItem.inj_SortNetworkCell
-  retr
-    | SortKItem.inj_SortNetworkCell x => some x
-    | _ => none
-
-instance : Inj SortOriginCell SortKItem where
-  inj := SortKItem.inj_SortOriginCell
-  retr
-    | SortKItem.inj_SortOriginCell x => some x
-    | _ => none
-
-instance : Inj SortStatusCode SortKItem where
-  inj := SortKItem.inj_SortStatusCode
-  retr
-    | SortKItem.inj_SortStatusCode x => some x
-    | _ => none
-
-instance : Inj SortTxTypeCell SortKItem where
-  inj := SortKItem.inj_SortTxTypeCell
-  retr
-    | SortKItem.inj_SortTxTypeCell x => some x
-    | _ => none
-
-instance : Inj SortJSONKey SortKItem where
-  inj
-    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
-  retr
-    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
-    | SortKItem.inj_SortJSONKey x => some x
-    | _ => none
-
-instance : Inj SortIdCell SortKItem where
-  inj := SortKItem.inj_SortIdCell
-  retr
-    | SortKItem.inj_SortIdCell x => some x
-    | _ => none
-
-instance : Inj SortTxType SortKItem where
-  inj := SortKItem.inj_SortTxType
-  retr
-    | SortKItem.inj_SortTxType x => some x
-    | _ => none
-
-instance : Inj SortGeneratedCounterCell SortKItem where
-  inj := SortKItem.inj_SortGeneratedCounterCell
-  retr
-    | SortKItem.inj_SortGeneratedCounterCell x => some x
-    | _ => none
-
-instance : Inj SortBytes SortKItem where
-  inj := SortKItem.inj_SortBytes
-  retr
-    | SortKItem.inj_SortBytes x => some x
-    | _ => none
-
-instance : Inj SortTouchedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortTouchedAccountsCell
-  retr
-    | SortKItem.inj_SortTouchedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortOmmersHashCell SortKItem where
-  inj := SortKItem.inj_SortOmmersHashCell
-  retr
-    | SortKItem.inj_SortOmmersHashCell x => some x
-    | _ => none
-
-instance : Inj SortStateRootCell SortKItem where
-  inj := SortKItem.inj_SortStateRootCell
-  retr
-    | SortKItem.inj_SortStateRootCell x => some x
-    | _ => none
-
-instance : Inj SortAddressCell SortKItem where
-  inj := SortKItem.inj_SortAddressCell
-  retr
-    | SortKItem.inj_SortAddressCell x => some x
-    | _ => none
-
-instance : Inj SortAccessedAccountsCell SortKItem where
-  inj := SortKItem.inj_SortAccessedAccountsCell
-  retr
-    | SortKItem.inj_SortAccessedAccountsCell x => some x
-    | _ => none
-
-instance : Inj SortTxMaxFeeCell SortKItem where
-  inj := SortKItem.inj_SortTxMaxFeeCell
-  retr
-    | SortKItem.inj_SortTxMaxFeeCell x => some x
-    | _ => none
-
-instance : Inj SortCoinbaseCell SortKItem where
-  inj := SortKItem.inj_SortCoinbaseCell
-  retr
-    | SortKItem.inj_SortCoinbaseCell x => some x
-    | _ => none
-
-instance : Inj SortScheduleFlag SortKItem where
-  inj := SortKItem.inj_SortScheduleFlag
-  retr
-    | SortKItem.inj_SortScheduleFlag x => some x
-    | _ => none
-
-instance : Inj SortLogCell SortKItem where
-  inj := SortKItem.inj_SortLogCell
-  retr
-    | SortKItem.inj_SortLogCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsPendingCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsPendingCell
-  retr
-    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
-    | _ => none
-
-instance : Inj SortTimestampCell SortKItem where
-  inj := SortKItem.inj_SortTimestampCell
-  retr
-    | SortKItem.inj_SortTimestampCell x => some x
-    | _ => none
-
-instance : Inj SortGasLimitCell SortKItem where
-  inj := SortKItem.inj_SortGasLimitCell
-  retr
-    | SortKItem.inj_SortGasLimitCell x => some x
-    | _ => none
-
-instance : Inj SortSignedness SortKItem where
-  inj := SortKItem.inj_SortSignedness
-  retr
-    | SortKItem.inj_SortSignedness x => some x
-    | _ => none
-
-instance : Inj SortNumberCell SortKItem where
-  inj := SortKItem.inj_SortNumberCell
-  retr
-    | SortKItem.inj_SortNumberCell x => some x
-    | _ => none
-
-instance : Inj SortVersionedHashesCell SortKItem where
-  inj := SortKItem.inj_SortVersionedHashesCell
-  retr
-    | SortKItem.inj_SortVersionedHashesCell x => some x
-    | _ => none
-
-instance : Inj SortAccessedStorageCell SortKItem where
-  inj := SortKItem.inj_SortAccessedStorageCell
-  retr
-    | SortKItem.inj_SortAccessedStorageCell x => some x
-    | _ => none
-
-instance : Inj SortStorageCell SortKItem where
-  inj := SortKItem.inj_SortStorageCell
-  retr
-    | SortKItem.inj_SortStorageCell x => some x
-    | _ => none
-
-instance : Inj SortTxChainIDCell SortKItem where
-  inj := SortKItem.inj_SortTxChainIDCell
-  retr
-    | SortKItem.inj_SortTxChainIDCell x => some x
-    | _ => none
-
-instance : Inj SortGasPriceCell SortKItem where
-  inj := SortKItem.inj_SortGasPriceCell
-  retr
-    | SortKItem.inj_SortGasPriceCell x => some x
-    | _ => none
-
-instance : Inj SortCallDataCell SortKItem where
-  inj := SortKItem.inj_SortCallDataCell
-  retr
-    | SortKItem.inj_SortCallDataCell x => some x
-    | _ => none
-
-instance : Inj SortBlockhashesCell SortKItem where
-  inj := SortKItem.inj_SortBlockhashesCell
-  retr
-    | SortKItem.inj_SortBlockhashesCell x => some x
-    | _ => none
-
-instance : Inj SortInternalOp SortKItem where
-  inj := SortKItem.inj_SortInternalOp
-  retr
-    | SortKItem.inj_SortInternalOp x => some x
-    | _ => none
-
-instance : Inj SortExcessBlobGasCell SortKItem where
-  inj := SortKItem.inj_SortExcessBlobGasCell
-  retr
-    | SortKItem.inj_SortExcessBlobGasCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsRootCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsRootCell
-  retr
-    | SortKItem.inj_SortWithdrawalsRootCell x => some x
-    | _ => none
-
-instance : Inj SortTransactionsRootCell SortKItem where
-  inj := SortKItem.inj_SortTransactionsRootCell
-  retr
-    | SortKItem.inj_SortTransactionsRootCell x => some x
-    | _ => none
-
-instance : Inj SortWithdrawalsCell SortKItem where
-  inj := SortKItem.inj_SortWithdrawalsCell
-  retr
-    | SortKItem.inj_SortWithdrawalsCell x => some x
-    | _ => none
-
-instance : Inj SortUnStackOp SortKItem where
-  inj := SortKItem.inj_SortUnStackOp
-  retr
-    | SortKItem.inj_SortUnStackOp x => some x
-    | _ => none
-
-instance : Inj SortOrigStorageCell SortKItem where
-  inj := SortKItem.inj_SortOrigStorageCell
-  retr
-    | SortKItem.inj_SortOrigStorageCell x => some x
+    | SortKItem.inj_SortOutputCell x => some x
     | _ => none
 
 instance : Inj SortTxPendingCell SortKItem where
@@ -743,16 +60,28 @@ instance : Inj SortTxPendingCell SortKItem where
     | SortKItem.inj_SortTxPendingCell x => some x
     | _ => none
 
-instance : Inj SortSelfDestructCell SortKItem where
-  inj := SortKItem.inj_SortSelfDestructCell
+instance : Inj SortStateRootCell SortKItem where
+  inj := SortKItem.inj_SortStateRootCell
   retr
-    | SortKItem.inj_SortSelfDestructCell x => some x
+    | SortKItem.inj_SortStateRootCell x => some x
     | _ => none
 
-instance : Inj SortInterimStatesCell SortKItem where
-  inj := SortKItem.inj_SortInterimStatesCell
+instance : Inj SortSigVCell SortKItem where
+  inj := SortKItem.inj_SortSigVCell
   retr
-    | SortKItem.inj_SortInterimStatesCell x => some x
+    | SortKItem.inj_SortSigVCell x => some x
+    | _ => none
+
+instance : Inj SortCreatedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortCreatedAccountsCell
+  retr
+    | SortKItem.inj_SortCreatedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortNonceCell SortKItem where
+  inj := SortKItem.inj_SortNonceCell
+  retr
+    | SortKItem.inj_SortNonceCell x => some x
     | _ => none
 
 instance : Inj SortJSON SortKItem where
@@ -774,28 +103,123 @@ instance : Inj SortJSON SortKItem where
     | SortKItem.inj_SortJSON x => some x
     | _ => none
 
-instance : Inj SortPreviousHashCell SortKItem where
-  inj := SortKItem.inj_SortPreviousHashCell
+instance : Inj SortCallerCell SortKItem where
+  inj := SortKItem.inj_SortCallerCell
   retr
-    | SortKItem.inj_SortPreviousHashCell x => some x
+    | SortKItem.inj_SortCallerCell x => some x
     | _ => none
 
-instance : Inj SortMemoryUsedCell SortKItem where
-  inj := SortKItem.inj_SortMemoryUsedCell
+instance : Inj SortScheduleCell SortKItem where
+  inj := SortKItem.inj_SortScheduleCell
   retr
-    | SortKItem.inj_SortMemoryUsedCell x => some x
+    | SortKItem.inj_SortScheduleCell x => some x
     | _ => none
 
-instance : Inj SortSubstateCell SortKItem where
-  inj := SortKItem.inj_SortSubstateCell
+instance : Inj SortReceiptsRootCell SortKItem where
+  inj := SortKItem.inj_SortReceiptsRootCell
   retr
-    | SortKItem.inj_SortSubstateCell x => some x
+    | SortKItem.inj_SortReceiptsRootCell x => some x
     | _ => none
 
-instance : Inj SortMixHashCell SortKItem where
-  inj := SortKItem.inj_SortMixHashCell
+instance : Inj SortWithdrawalsOrderCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsOrderCell
   retr
-    | SortKItem.inj_SortMixHashCell x => some x
+    | SortKItem.inj_SortWithdrawalsOrderCell x => some x
+    | _ => none
+
+instance : Inj SortSchedule SortKItem where
+  inj := SortKItem.inj_SortSchedule
+  retr
+    | SortKItem.inj_SortSchedule x => some x
+    | _ => none
+
+instance : Inj SortPushOp SortKItem where
+  inj := SortKItem.inj_SortPushOp
+  retr
+    | SortKItem.inj_SortPushOp x => some x
+    | _ => none
+
+instance : Inj SortAccessedStorageCell SortKItem where
+  inj := SortKItem.inj_SortAccessedStorageCell
+  retr
+    | SortKItem.inj_SortAccessedStorageCell x => some x
+    | _ => none
+
+instance : Inj SortStatusCode SortKItem where
+  inj := SortKItem.inj_SortStatusCode
+  retr
+    | SortKItem.inj_SortStatusCode x => some x
+    | _ => none
+
+instance : Inj SortGas SortKItem where
+  inj
+    | SortGas.inj_SortInt x => SortKItem.inj_SortInt x
+  retr
+    | SortKItem.inj_SortInt x => some (SortGas.inj_SortInt x)
+    | SortKItem.inj_SortGas x => some x
+    | _ => none
+
+instance : Inj SortTxMaxFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxFeeCell
+  retr
+    | SortKItem.inj_SortTxMaxFeeCell x => some x
+    | _ => none
+
+instance : Inj SortSigSCell SortKItem where
+  inj := SortKItem.inj_SortSigSCell
+  retr
+    | SortKItem.inj_SortSigSCell x => some x
+    | _ => none
+
+instance : Inj SortBinStackOp SortKItem where
+  inj := SortKItem.inj_SortBinStackOp
+  retr
+    | SortKItem.inj_SortBinStackOp x => some x
+    | _ => none
+
+instance : Inj SortSignedness SortKItem where
+  inj := SortKItem.inj_SortSignedness
+  retr
+    | SortKItem.inj_SortSignedness x => some x
+    | _ => none
+
+instance : Inj SortCallStateCell SortKItem where
+  inj := SortKItem.inj_SortCallStateCell
+  retr
+    | SortKItem.inj_SortCallStateCell x => some x
+    | _ => none
+
+instance : Inj SortTransactionsRootCell SortKItem where
+  inj := SortKItem.inj_SortTransactionsRootCell
+  retr
+    | SortKItem.inj_SortTransactionsRootCell x => some x
+    | _ => none
+
+instance : Inj SortAccount SortKItem where
+  inj
+    | SortAccount.inj_SortInt x => SortKItem.inj_SortInt x
+    | x => SortKItem.inj_SortAccount x
+  retr
+    | SortKItem.inj_SortInt x => some (SortAccount.inj_SortInt x)
+    | SortKItem.inj_SortAccount x => some x
+    | _ => none
+
+instance : Inj SortTxChainIDCell SortKItem where
+  inj := SortKItem.inj_SortTxChainIDCell
+  retr
+    | SortKItem.inj_SortTxChainIDCell x => some x
+    | _ => none
+
+instance : Inj SortTxNonceCell SortKItem where
+  inj := SortKItem.inj_SortTxNonceCell
+  retr
+    | SortKItem.inj_SortTxNonceCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCellMap SortKItem where
+  inj := SortKItem.inj_SortAccountCellMap
+  retr
+    | SortKItem.inj_SortAccountCellMap x => some x
     | _ => none
 
 instance : Inj SortJSONs SortKItem where
@@ -804,22 +228,186 @@ instance : Inj SortJSONs SortKItem where
     | SortKItem.inj_SortJSONs x => some x
     | _ => none
 
+instance : Inj SortWithdrawalsCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsCell
+  retr
+    | SortKItem.inj_SortWithdrawalsCell x => some x
+    | _ => none
+
+instance : Inj SortInt SortKItem where
+  inj := SortKItem.inj_SortInt
+  retr
+    | SortKItem.inj_SortInt x => some x
+    | _ => none
+
+instance : Inj SortTxPriorityFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxPriorityFeeCell
+  retr
+    | SortKItem.inj_SortTxPriorityFeeCell x => some x
+    | _ => none
+
+instance : Inj SortBlockNonceCell SortKItem where
+  inj := SortKItem.inj_SortBlockNonceCell
+  retr
+    | SortKItem.inj_SortBlockNonceCell x => some x
+    | _ => none
+
+instance : Inj SortBool SortKItem where
+  inj := SortKItem.inj_SortBool
+  retr
+    | SortKItem.inj_SortBool x => some x
+    | _ => none
+
+instance : Inj SortTxType SortKItem where
+  inj := SortKItem.inj_SortTxType
+  retr
+    | SortKItem.inj_SortTxType x => some x
+    | _ => none
+
+instance : Inj SortCallValueCell SortKItem where
+  inj := SortKItem.inj_SortCallValueCell
+  retr
+    | SortKItem.inj_SortCallValueCell x => some x
+    | _ => none
+
+instance : Inj SortLogCell SortKItem where
+  inj := SortKItem.inj_SortLogCell
+  retr
+    | SortKItem.inj_SortLogCell x => some x
+    | _ => none
+
+instance : Inj SortBlockhashesCell SortKItem where
+  inj := SortKItem.inj_SortBlockhashesCell
+  retr
+    | SortKItem.inj_SortBlockhashesCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalCellMap SortKItem where
+  inj := SortKItem.inj_SortWithdrawalCellMap
+  retr
+    | SortKItem.inj_SortWithdrawalCellMap x => some x
+    | _ => none
+
 instance : Inj SortEthereumCell SortKItem where
   inj := SortKItem.inj_SortEthereumCell
   retr
     | SortKItem.inj_SortEthereumCell x => some x
     | _ => none
 
-instance : Inj SortWordStack SortKItem where
-  inj := SortKItem.inj_SortWordStack
+instance : Inj SortModeCell SortKItem where
+  inj := SortKItem.inj_SortModeCell
   retr
-    | SortKItem.inj_SortWordStack x => some x
+    | SortKItem.inj_SortModeCell x => some x
     | _ => none
 
-instance : Inj SortMap SortKItem where
-  inj := SortKItem.inj_SortMap
+instance : Inj SortGasPriceCell SortKItem where
+  inj := SortKItem.inj_SortGasPriceCell
   retr
-    | SortKItem.inj_SortMap x => some x
+    | SortKItem.inj_SortGasPriceCell x => some x
+    | _ => none
+
+instance : Inj SortLocalMemCell SortKItem where
+  inj := SortKItem.inj_SortLocalMemCell
+  retr
+    | SortKItem.inj_SortLocalMemCell x => some x
+    | _ => none
+
+instance : Inj SortAddressCell SortKItem where
+  inj := SortKItem.inj_SortAddressCell
+  retr
+    | SortKItem.inj_SortAddressCell x => some x
+    | _ => none
+
+instance : Inj SortAccessedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortAccessedAccountsCell
+  retr
+    | SortKItem.inj_SortAccessedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortKevmCell SortKItem where
+  inj := SortKItem.inj_SortKevmCell
+  retr
+    | SortKItem.inj_SortKevmCell x => some x
+    | _ => none
+
+instance : Inj SortBalanceCell SortKItem where
+  inj := SortKItem.inj_SortBalanceCell
+  retr
+    | SortKItem.inj_SortBalanceCell x => some x
+    | _ => none
+
+instance : Inj SortGeneratedTopCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedTopCell
+  retr
+    | SortKItem.inj_SortGeneratedTopCell x => some x
+    | _ => none
+
+instance : Inj SortRefundCell SortKItem where
+  inj := SortKItem.inj_SortRefundCell
+  retr
+    | SortKItem.inj_SortRefundCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalIDCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalIDCell
+  retr
+    | SortKItem.inj_SortWithdrawalIDCell x => some x
+    | _ => none
+
+instance : Inj SortTxGasPriceCell SortKItem where
+  inj := SortKItem.inj_SortTxGasPriceCell
+  retr
+    | SortKItem.inj_SortTxGasPriceCell x => some x
+    | _ => none
+
+instance : Inj SortSelfDestructCell SortKItem where
+  inj := SortKItem.inj_SortSelfDestructCell
+  retr
+    | SortKItem.inj_SortSelfDestructCell x => some x
+    | _ => none
+
+instance : Inj SortBytes SortKItem where
+  inj := SortKItem.inj_SortBytes
+  retr
+    | SortKItem.inj_SortBytes x => some x
+    | _ => none
+
+instance : Inj SortExtraDataCell SortKItem where
+  inj := SortKItem.inj_SortExtraDataCell
+  retr
+    | SortKItem.inj_SortExtraDataCell x => some x
+    | _ => none
+
+instance : Inj SortGasLimitCell SortKItem where
+  inj := SortKItem.inj_SortGasLimitCell
+  retr
+    | SortKItem.inj_SortGasLimitCell x => some x
+    | _ => none
+
+instance : Inj SortJSONKey SortKItem where
+  inj
+    | SortJSONKey.inj_SortInt x => SortKItem.inj_SortInt x
+  retr
+    | SortKItem.inj_SortInt x => some (SortJSONKey.inj_SortInt x)
+    | SortKItem.inj_SortJSONKey x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsRootCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsRootCell
+  retr
+    | SortKItem.inj_SortWithdrawalsRootCell x => some x
+    | _ => none
+
+instance : Inj SortValueCell SortKItem where
+  inj := SortKItem.inj_SortValueCell
+  retr
+    | SortKItem.inj_SortValueCell x => some x
+    | _ => none
+
+instance : Inj SortTxGasLimitCell SortKItem where
+  inj := SortKItem.inj_SortTxGasLimitCell
+  retr
+    | SortKItem.inj_SortTxGasLimitCell x => some x
     | _ => none
 
 instance : Inj SortDataCell SortKItem where
@@ -828,27 +416,433 @@ instance : Inj SortDataCell SortKItem where
     | SortKItem.inj_SortDataCell x => some x
     | _ => none
 
+instance : Inj SortScheduleConst SortKItem where
+  inj := SortKItem.inj_SortScheduleConst
+  retr
+    | SortKItem.inj_SortScheduleConst x => some x
+    | _ => none
+
+instance : Inj SortDifficultyCell SortKItem where
+  inj := SortKItem.inj_SortDifficultyCell
+  retr
+    | SortKItem.inj_SortDifficultyCell x => some x
+    | _ => none
+
+instance : Inj SortInterimStatesCell SortKItem where
+  inj := SortKItem.inj_SortInterimStatesCell
+  retr
+    | SortKItem.inj_SortInterimStatesCell x => some x
+    | _ => none
+
+instance : Inj SortMessageCellMap SortKItem where
+  inj := SortKItem.inj_SortMessageCellMap
+  retr
+    | SortKItem.inj_SortMessageCellMap x => some x
+    | _ => none
+
+instance : Inj SortStaticCell SortKItem where
+  inj := SortKItem.inj_SortStaticCell
+  retr
+    | SortKItem.inj_SortStaticCell x => some x
+    | _ => none
+
+instance : Inj SortPreviousHashCell SortKItem where
+  inj := SortKItem.inj_SortPreviousHashCell
+  retr
+    | SortKItem.inj_SortPreviousHashCell x => some x
+    | _ => none
+
+instance : Inj SortBlockCell SortKItem where
+  inj := SortKItem.inj_SortBlockCell
+  retr
+    | SortKItem.inj_SortBlockCell x => some x
+    | _ => none
+
+instance : Inj SortGasCell SortKItem where
+  inj := SortKItem.inj_SortGasCell
+  retr
+    | SortKItem.inj_SortGasCell x => some x
+    | _ => none
+
+instance : Inj SortCallGasCell SortKItem where
+  inj := SortKItem.inj_SortCallGasCell
+  retr
+    | SortKItem.inj_SortCallGasCell x => some x
+    | _ => none
+
+instance : Inj SortCallDataCell SortKItem where
+  inj := SortKItem.inj_SortCallDataCell
+  retr
+    | SortKItem.inj_SortCallDataCell x => some x
+    | _ => none
+
+instance : Inj SortChainIDCell SortKItem where
+  inj := SortKItem.inj_SortChainIDCell
+  retr
+    | SortKItem.inj_SortChainIDCell x => some x
+    | _ => none
+
+instance : Inj SortAmountCell SortKItem where
+  inj := SortKItem.inj_SortAmountCell
+  retr
+    | SortKItem.inj_SortAmountCell x => some x
+    | _ => none
+
+instance : Inj SortMap SortKItem where
+  inj := SortKItem.inj_SortMap
+  retr
+    | SortKItem.inj_SortMap x => some x
+    | _ => none
+
+instance : Inj SortExcessBlobGasCell SortKItem where
+  inj := SortKItem.inj_SortExcessBlobGasCell
+  retr
+    | SortKItem.inj_SortExcessBlobGasCell x => some x
+    | _ => none
+
+instance : Inj SortProgramCell SortKItem where
+  inj := SortKItem.inj_SortProgramCell
+  retr
+    | SortKItem.inj_SortProgramCell x => some x
+    | _ => none
+
+instance : Inj SortMessageCell SortKItem where
+  inj := SortKItem.inj_SortMessageCell
+  retr
+    | SortKItem.inj_SortMessageCell x => some x
+    | _ => none
+
+instance : Inj SortStorageCell SortKItem where
+  inj := SortKItem.inj_SortStorageCell
+  retr
+    | SortKItem.inj_SortStorageCell x => some x
+    | _ => none
+
+instance : Inj SortEvmCell SortKItem where
+  inj := SortKItem.inj_SortEvmCell
+  retr
+    | SortKItem.inj_SortEvmCell x => some x
+    | _ => none
+
+instance : Inj SortWordStack SortKItem where
+  inj := SortKItem.inj_SortWordStack
+  retr
+    | SortKItem.inj_SortWordStack x => some x
+    | _ => none
+
+instance : Inj SortVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortVersionedHashesCell
+  retr
+    | SortKItem.inj_SortVersionedHashesCell x => some x
+    | _ => none
+
+instance : Inj SortOrigStorageCell SortKItem where
+  inj := SortKItem.inj_SortOrigStorageCell
+  retr
+    | SortKItem.inj_SortOrigStorageCell x => some x
+    | _ => none
+
+instance : Inj SortTxTypeCell SortKItem where
+  inj := SortKItem.inj_SortTxTypeCell
+  retr
+    | SortKItem.inj_SortTxTypeCell x => some x
+    | _ => none
+
+instance : Inj SortMemoryUsedCell SortKItem where
+  inj := SortKItem.inj_SortMemoryUsedCell
+  retr
+    | SortKItem.inj_SortMemoryUsedCell x => some x
+    | _ => none
+
+instance : Inj SortGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortGasUsedCell
+  retr
+    | SortKItem.inj_SortGasUsedCell x => some x
+    | _ => none
+
+instance : Inj SortToCell SortKItem where
+  inj := SortKItem.inj_SortToCell
+  retr
+    | SortKItem.inj_SortToCell x => some x
+    | _ => none
+
+instance : Inj SortAcctIDCell SortKItem where
+  inj := SortKItem.inj_SortAcctIDCell
+  retr
+    | SortKItem.inj_SortAcctIDCell x => some x
+    | _ => none
+
+instance : Inj SortIndexCell SortKItem where
+  inj := SortKItem.inj_SortIndexCell
+  retr
+    | SortKItem.inj_SortIndexCell x => some x
+    | _ => none
+
+instance : Inj SortBeaconRootCell SortKItem where
+  inj := SortKItem.inj_SortBeaconRootCell
+  retr
+    | SortKItem.inj_SortBeaconRootCell x => some x
+    | _ => none
+
+instance : Inj SortCallStackCell SortKItem where
+  inj := SortKItem.inj_SortCallStackCell
+  retr
+    | SortKItem.inj_SortCallStackCell x => some x
+    | _ => none
+
+instance : Inj SortCallDepthCell SortKItem where
+  inj := SortKItem.inj_SortCallDepthCell
+  retr
+    | SortKItem.inj_SortCallDepthCell x => some x
+    | _ => none
+
+instance : Inj SortWordStackCell SortKItem where
+  inj := SortKItem.inj_SortWordStackCell
+  retr
+    | SortKItem.inj_SortWordStackCell x => some x
+    | _ => none
+
+instance : Inj SortTxVersionedHashesCell SortKItem where
+  inj := SortKItem.inj_SortTxVersionedHashesCell
+  retr
+    | SortKItem.inj_SortTxVersionedHashesCell x => some x
+    | _ => none
+
+instance : Inj SortGeneratedCounterCell SortKItem where
+  inj := SortKItem.inj_SortGeneratedCounterCell
+  retr
+    | SortKItem.inj_SortGeneratedCounterCell x => some x
+    | _ => none
+
+instance : Inj SortUnStackOp SortKItem where
+  inj := SortKItem.inj_SortUnStackOp
+  retr
+    | SortKItem.inj_SortUnStackOp x => some x
+    | _ => none
+
+instance : Inj SortCodeCell SortKItem where
+  inj := SortKItem.inj_SortCodeCell
+  retr
+    | SortKItem.inj_SortCodeCell x => some x
+    | _ => none
+
+instance : Inj SortBlobGasUsedCell SortKItem where
+  inj := SortKItem.inj_SortBlobGasUsedCell
+  retr
+    | SortKItem.inj_SortBlobGasUsedCell x => some x
+    | _ => none
+
+instance : Inj SortNetworkCell SortKItem where
+  inj := SortKItem.inj_SortNetworkCell
+  retr
+    | SortKItem.inj_SortNetworkCell x => some x
+    | _ => none
+
+instance : Inj SortScheduleFlag SortKItem where
+  inj := SortKItem.inj_SortScheduleFlag
+  retr
+    | SortKItem.inj_SortScheduleFlag x => some x
+    | _ => none
+
+instance : Inj SortMode SortKItem where
+  inj := SortKItem.inj_SortMode
+  retr
+    | SortKItem.inj_SortMode x => some x
+    | _ => none
+
+instance : Inj SortSigRCell SortKItem where
+  inj := SortKItem.inj_SortSigRCell
+  retr
+    | SortKItem.inj_SortSigRCell x => some x
+    | _ => none
+
+instance : Inj SortPcCell SortKItem where
+  inj := SortKItem.inj_SortPcCell
+  retr
+    | SortKItem.inj_SortPcCell x => some x
+    | _ => none
+
+instance : Inj SortOmmersHashCell SortKItem where
+  inj := SortKItem.inj_SortOmmersHashCell
+  retr
+    | SortKItem.inj_SortOmmersHashCell x => some x
+    | _ => none
+
+instance : Inj SortTimestampCell SortKItem where
+  inj := SortKItem.inj_SortTimestampCell
+  retr
+    | SortKItem.inj_SortTimestampCell x => some x
+    | _ => none
+
+instance : Inj SortMaybeOpCode SortKItem where
+  inj
+    | SortMaybeOpCode.inj_SortBinStackOp x => SortKItem.inj_SortBinStackOp x
+    | SortMaybeOpCode.inj_SortInternalOp x => SortKItem.inj_SortInternalOp x
+    | SortMaybeOpCode.inj_SortPushOp x => SortKItem.inj_SortPushOp x
+    | SortMaybeOpCode.inj_SortUnStackOp x => SortKItem.inj_SortUnStackOp x
+  retr
+    | SortKItem.inj_SortBinStackOp x => some (SortMaybeOpCode.inj_SortBinStackOp x)
+    | SortKItem.inj_SortInternalOp x => some (SortMaybeOpCode.inj_SortInternalOp x)
+    | SortKItem.inj_SortPushOp x => some (SortMaybeOpCode.inj_SortPushOp x)
+    | SortKItem.inj_SortUnStackOp x => some (SortMaybeOpCode.inj_SortUnStackOp x)
+    | SortKItem.inj_SortMaybeOpCode x => some x
+    | _ => none
+
+instance : Inj SortKCell SortKItem where
+  inj := SortKItem.inj_SortKCell
+  retr
+    | SortKItem.inj_SortKCell x => some x
+    | _ => none
+
+instance : Inj SortTxAccessCell SortKItem where
+  inj := SortKItem.inj_SortTxAccessCell
+  retr
+    | SortKItem.inj_SortTxAccessCell x => some x
+    | _ => none
+
+instance : Inj SortExitCodeCell SortKItem where
+  inj := SortKItem.inj_SortExitCodeCell
+  retr
+    | SortKItem.inj_SortExitCodeCell x => some x
+    | _ => none
+
+instance : Inj SortJumpDestsCell SortKItem where
+  inj := SortKItem.inj_SortJumpDestsCell
+  retr
+    | SortKItem.inj_SortJumpDestsCell x => some x
+    | _ => none
+
+instance : Inj SortOriginCell SortKItem where
+  inj := SortKItem.inj_SortOriginCell
+  retr
+    | SortKItem.inj_SortOriginCell x => some x
+    | _ => none
+
+instance : Inj SortTouchedAccountsCell SortKItem where
+  inj := SortKItem.inj_SortTouchedAccountsCell
+  retr
+    | SortKItem.inj_SortTouchedAccountsCell x => some x
+    | _ => none
+
+instance : Inj SortBaseFeeCell SortKItem where
+  inj := SortKItem.inj_SortBaseFeeCell
+  retr
+    | SortKItem.inj_SortBaseFeeCell x => some x
+    | _ => none
+
+instance : Inj SortEndianness SortKItem where
+  inj := SortKItem.inj_SortEndianness
+  retr
+    | SortKItem.inj_SortEndianness x => some x
+    | _ => none
+
+instance : Inj SortInternalOp SortKItem where
+  inj := SortKItem.inj_SortInternalOp
+  retr
+    | SortKItem.inj_SortInternalOp x => some x
+    | _ => none
+
+instance : Inj SortOmmerBlockHeadersCell SortKItem where
+  inj := SortKItem.inj_SortOmmerBlockHeadersCell
+  retr
+    | SortKItem.inj_SortOmmerBlockHeadersCell x => some x
+    | _ => none
+
+instance : Inj SortTxMaxBlobFeeCell SortKItem where
+  inj := SortKItem.inj_SortTxMaxBlobFeeCell
+  retr
+    | SortKItem.inj_SortTxMaxBlobFeeCell x => some x
+    | _ => none
+
+instance : Inj SortSubstateCell SortKItem where
+  inj := SortKItem.inj_SortSubstateCell
+  retr
+    | SortKItem.inj_SortSubstateCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCode SortKItem where
+  inj
+    | SortAccountCode.inj_SortBytes x => SortKItem.inj_SortBytes x
+  retr
+    | SortKItem.inj_SortBytes x => some (SortAccountCode.inj_SortBytes x)
+    | SortKItem.inj_SortAccountCode x => some x
+    | _ => none
+
+instance : Inj SortMessagesCell SortKItem where
+  inj := SortKItem.inj_SortMessagesCell
+  retr
+    | SortKItem.inj_SortMessagesCell x => some x
+    | _ => none
+
+instance : Inj SortIdCell SortKItem where
+  inj := SortKItem.inj_SortIdCell
+  retr
+    | SortKItem.inj_SortIdCell x => some x
+    | _ => none
+
+instance : Inj SortMsgIDCell SortKItem where
+  inj := SortKItem.inj_SortMsgIDCell
+  retr
+    | SortKItem.inj_SortMsgIDCell x => some x
+    | _ => none
+
+instance : Inj SortNumberCell SortKItem where
+  inj := SortKItem.inj_SortNumberCell
+  retr
+    | SortKItem.inj_SortNumberCell x => some x
+    | _ => none
+
+instance : Inj SortSet SortKItem where
+  inj := SortKItem.inj_SortSet
+  retr
+    | SortKItem.inj_SortSet x => some x
+    | _ => none
+
+instance : Inj SortValidatorIndexCell SortKItem where
+  inj := SortKItem.inj_SortValidatorIndexCell
+  retr
+    | SortKItem.inj_SortValidatorIndexCell x => some x
+    | _ => none
+
+instance : Inj SortCoinbaseCell SortKItem where
+  inj := SortKItem.inj_SortCoinbaseCell
+  retr
+    | SortKItem.inj_SortCoinbaseCell x => some x
+    | _ => none
+
+instance : Inj SortWithdrawalsPendingCell SortKItem where
+  inj := SortKItem.inj_SortWithdrawalsPendingCell
+  retr
+    | SortKItem.inj_SortWithdrawalsPendingCell x => some x
+    | _ => none
+
+instance : Inj SortTransientStorageCell SortKItem where
+  inj := SortKItem.inj_SortTransientStorageCell
+  retr
+    | SortKItem.inj_SortTransientStorageCell x => some x
+    | _ => none
+
+instance : Inj SortAccountCell SortKItem where
+  inj := SortKItem.inj_SortAccountCell
+  retr
+    | SortKItem.inj_SortAccountCell x => some x
+    | _ => none
+
 instance : Inj SortInt SortGas where
   inj := SortGas.inj_SortInt
   retr
     | SortGas.inj_SortInt x => some x
 
-instance : Inj SortBool SortJSON where
-  inj := SortJSON.inj_SortBool
-  retr
-    | SortJSON.inj_SortBool x => some x
-    | _ => none
-
-instance : Inj SortBytes SortJSON where
-  inj := SortJSON.inj_SortBytes
-  retr
-    | SortJSON.inj_SortBytes x => some x
-    | _ => none
-
 instance : Inj SortInt SortJSON where
   inj := SortJSON.inj_SortInt
   retr
     | SortJSON.inj_SortInt x => some x
+    | _ => none
+
+instance : Inj SortMap SortJSON where
+  inj := SortJSON.inj_SortMap
+  retr
+    | SortJSON.inj_SortMap x => some x
     | _ => none
 
 instance : Inj SortAccount SortJSON where
@@ -860,10 +854,16 @@ instance : Inj SortAccount SortJSON where
     | SortJSON.inj_SortAccount x => some x
     | _ => none
 
-instance : Inj SortMap SortJSON where
-  inj := SortJSON.inj_SortMap
+instance : Inj SortBool SortJSON where
+  inj := SortJSON.inj_SortBool
   retr
-    | SortJSON.inj_SortMap x => some x
+    | SortJSON.inj_SortBool x => some x
+    | _ => none
+
+instance : Inj SortBytes SortJSON where
+  inj := SortJSON.inj_SortBytes
+  retr
+    | SortJSON.inj_SortBytes x => some x
     | _ => none
 
 instance : Inj SortTxType SortJSON where
@@ -883,6 +883,12 @@ instance : Inj SortInternalOp SortMaybeOpCode where
     | SortMaybeOpCode.inj_SortInternalOp x => some x
     | _ => none
 
+instance : Inj SortPushOp SortMaybeOpCode where
+  inj := SortMaybeOpCode.inj_SortPushOp
+  retr
+    | SortMaybeOpCode.inj_SortPushOp x => some x
+    | _ => none
+
 instance : Inj SortUnStackOp SortMaybeOpCode where
   inj := SortMaybeOpCode.inj_SortUnStackOp
   retr
@@ -893,12 +899,6 @@ instance : Inj SortBinStackOp SortMaybeOpCode where
   inj := SortMaybeOpCode.inj_SortBinStackOp
   retr
     | SortMaybeOpCode.inj_SortBinStackOp x => some x
-    | _ => none
-
-instance : Inj SortPushOp SortMaybeOpCode where
-  inj := SortMaybeOpCode.inj_SortPushOp
-  retr
-    | SortMaybeOpCode.inj_SortPushOp x => some x
     | _ => none
 
 instance : Inj SortInt SortAccount where

--- a/EvmEquivalence/KEVM2Lean/Rewrite.lean
+++ b/EvmEquivalence/KEVM2Lean/Rewrite.lean
@@ -250,6 +250,137 @@ inductive Rewrites : SortGeneratedTopCell → SortGeneratedTopCell → Prop wher
             block := _Gen19 },
           network := _DotVar2 } },
       generatedCounter := _DotVar0 }
+  | MSTORE8_SUMMARY_MSTORE8_SUMMARY_USEGAS
+    {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val14 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
+    {LOCALMEM_CELL _Val15 _Val16 : SortBytes}
+    {SCHEDULE_CELL : SortSchedule}
+    {USEGAS_CELL _Val11 _Val12 _Val13 _Val4 : SortBool}
+    {WS : SortWordStack}
+    {_DotVar0 : SortGeneratedCounterCell}
+    {_DotVar2 : SortNetworkCell}
+    {_Gen0 : SortProgramCell}
+    {_Gen1 : SortJumpDestsCell}
+    {_Gen10 : SortStatusCodeCell}
+    {_Gen11 : SortCallStackCell}
+    {_Gen12 : SortInterimStatesCell}
+    {_Gen13 : SortTouchedAccountsCell}
+    {_Gen14 : SortVersionedHashesCell}
+    {_Gen15 : SortSubstateCell}
+    {_Gen16 : SortGasPriceCell}
+    {_Gen17 : SortOriginCell}
+    {_Gen18 : SortBlockhashesCell}
+    {_Gen19 : SortBlockCell}
+    {_Gen2 : SortIdCell}
+    {_Gen20 : SortExitCodeCell}
+    {_Gen21 : SortModeCell}
+    {_Gen3 : SortCallerCell}
+    {_Gen4 : SortCallDataCell}
+    {_Gen5 : SortCallValueCell}
+    {_Gen6 : SortCallGasCell}
+    {_Gen7 : SortStaticCell}
+    {_Gen8 : SortCallDepthCell}
+    {_Gen9 : SortOutputCell}
+    {_K_CELL : SortK}
+    (defn_Val0 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 1 = some _Val0)
+    (defn_Val1 : Cmem SCHEDULE_CELL _Val0 = some _Val1)
+    (defn_Val2 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val2)
+    (defn_Val3 : «_-Int_» _Val1 _Val2 = some _Val3)
+    (defn_Val4 : «_<=Int_» _Val3 GAS_CELL = some _Val4)
+    (defn_Val5 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val5)
+    (defn_Val6 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 1 = some _Val6)
+    (defn_Val7 : Cmem SCHEDULE_CELL _Val6 = some _Val7)
+    (defn_Val8 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val8)
+    (defn_Val9 : «_-Int_» _Val7 _Val8 = some _Val9)
+    (defn_Val10 : «_-Int_» GAS_CELL _Val9 = some _Val10)
+    (defn_Val11 : «_<=Int_» _Val5 _Val10 = some _Val11)
+    (defn_Val12 : _andBool_ _Val4 _Val11 = some _Val12)
+    (defn_Val13 : _andBool_ USEGAS_CELL _Val12 = some _Val13)
+    (defn_Val14 : _modInt_ W1 256 = some _Val14)
+    (defn_Val15 : buf 1 _Val14 = some _Val15)
+    (defn_Val16 : mapWriteRange LOCALMEM_CELL W0 _Val15 = some _Val16)
+    (defn_Val17 : «_+Int_» PC_CELL 1 = some _Val17)
+    (defn_Val18 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 1 = some _Val18)
+    (defn_Val19 : Cmem SCHEDULE_CELL _Val18 = some _Val19)
+    (defn_Val20 : Cmem SCHEDULE_CELL MEMORYUSED_CELL = some _Val20)
+    (defn_Val21 : «_-Int_» _Val19 _Val20 = some _Val21)
+    (defn_Val22 : «_-Int_» GAS_CELL _Val21 = some _Val22)
+    (defn_Val23 : «_<_>_SCHEDULE_Int_ScheduleConst_Schedule» SortScheduleConst.Gverylow_SCHEDULE_ScheduleConst SCHEDULE_CELL = some _Val23)
+    (defn_Val24 : «_-Int_» _Val22 _Val23 = some _Val24)
+    (defn_Val25 : «#memoryUsageUpdate» MEMORYUSED_CELL W0 1 = some _Val25)
+    (req : _Val13 = true)
+    : Rewrites {
+      kevm := {
+        k := { val := SortK.kseq ((@inj SortInternalOp SortKItem) (SortInternalOp.«#next[_]_EVM_InternalOp_MaybeOpCode» ((@inj SortBinStackOp SortMaybeOpCode) SortBinStackOp.MSTORE8_EVM_BinStackOp))) _K_CELL },
+        exitCode := _Gen20,
+        mode := _Gen21,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := USEGAS_CELL },
+        ethereum := {
+          evm := {
+            output := _Gen9,
+            statusCode := _Gen10,
+            callStack := _Gen11,
+            interimStates := _Gen12,
+            touchedAccounts := _Gen13,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := _Gen2,
+              caller := _Gen3,
+              callData := _Gen4,
+              callValue := _Gen5,
+              wordStack := { val := SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W0 (SortWordStack.«_:__EVM-TYPES_WordStack_Int_WordStack» W1 WS) },
+              localMem := { val := LOCALMEM_CELL },
+              pc := { val := PC_CELL },
+              gas := { val := (@inj SortInt SortGas) GAS_CELL },
+              memoryUsed := { val := MEMORYUSED_CELL },
+              callGas := _Gen6,
+              static := _Gen7,
+              callDepth := _Gen8 },
+            versionedHashes := _Gen14,
+            substate := _Gen15,
+            gasPrice := _Gen16,
+            origin := _Gen17,
+            blockhashes := _Gen18,
+            block := _Gen19 },
+          network := _DotVar2 } },
+      generatedCounter := _DotVar0 } {
+      kevm := {
+        k := { val := _K_CELL },
+        exitCode := _Gen20,
+        mode := _Gen21,
+        schedule := { val := SCHEDULE_CELL },
+        useGas := { val := true },
+        ethereum := {
+          evm := {
+            output := _Gen9,
+            statusCode := _Gen10,
+            callStack := _Gen11,
+            interimStates := _Gen12,
+            touchedAccounts := _Gen13,
+            callState := {
+              program := _Gen0,
+              jumpDests := _Gen1,
+              id := _Gen2,
+              caller := _Gen3,
+              callData := _Gen4,
+              callValue := _Gen5,
+              wordStack := { val := WS },
+              localMem := { val := _Val16 },
+              pc := { val := _Val17 },
+              gas := { val := (@inj SortInt SortGas) _Val24 },
+              memoryUsed := { val := _Val25 },
+              callGas := _Gen6,
+              static := _Gen7,
+              callDepth := _Gen8 },
+            versionedHashes := _Gen14,
+            substate := _Gen15,
+            gasPrice := _Gen16,
+            origin := _Gen17,
+            blockhashes := _Gen18,
+            block := _Gen19 },
+          network := _DotVar2 } },
+      generatedCounter := _DotVar0 }
   | MSTORE_SUMMARY_MSTORE_SUMMARY_USEGAS
     {GAS_CELL MEMORYUSED_CELL PC_CELL W0 W1 _Val0 _Val1 _Val10 _Val17 _Val18 _Val19 _Val2 _Val20 _Val21 _Val22 _Val23 _Val24 _Val25 _Val3 _Val5 _Val6 _Val7 _Val8 _Val9 : SortInt}
     {LOCALMEM_CELL _Val14 _Val15 _Val16 : SortBytes}

--- a/EvmEquivalence/KEVM2Lean/Sorts.lean
+++ b/EvmEquivalence/KEVM2Lean/Sorts.lean
@@ -132,6 +132,7 @@ inductive SortScheduleFlag : Type where
 inductive SortBinStackOp : Type where
   | ADD_EVM_BinStackOp : SortBinStackOp
   | MSTORE_EVM_BinStackOp : SortBinStackOp
+  | MSTORE8_EVM_BinStackOp : SortBinStackOp
   | SSTORE_EVM_BinStackOp : SortBinStackOp
   deriving BEq, DecidableEq
 

--- a/EvmEquivalence/Summaries/MloadSummary.lean
+++ b/EvmEquivalence/Summaries/MloadSummary.lean
@@ -62,7 +62,7 @@ theorem EvmYul.step_mload_summary (symState : EVM.State):
   .ok {ss with
     stack := (EvmYul.MachineState.lookupMemory ss.toMachineState offset) :: symStack,
     pc := symPc + .ofNat 1,
-    activeWords := activeWords_comp offset symActiveWords} := by aesop
+    activeWords := activeWords_comp offset symActiveWords 32} := by aesop
 
 theorem EVM.step_mload_summary (gas_pos : 0 < gas) (symState : EVM.State):
   let ss := {symState with
@@ -86,7 +86,7 @@ theorem EVM.step_mload_summary (gas_pos : 0 < gas) (symState : EVM.State):
           stack := (EvmYul.MachineState.lookupMemory ss.toMachineState offset) :: symStack
           pc := symPc + (.ofNat 1),
           gasAvailable := symGasAvailable - UInt256.ofNat gasCost,
-          activeWords := activeWords_comp offset symActiveWords
+          activeWords := activeWords_comp offset symActiveWords 32
           execLength := symExecLength + 1} := by
   cases gas; contradiction
   simp [step_mload, EVM.step]
@@ -136,7 +136,7 @@ theorem X_mload_summary (symState : EVM.State)
           stack := (EvmYul.MachineState.lookupMemory ss.toMachineState offset) :: symStack,
           pc := .ofNat 1,
           gasAvailable := symGasAvailable - .ofNat (memoryExpansionCost ss mloadEVM) - .ofNat GasConstants.Gverylow,
-          activeWords := activeWords_comp offset symActiveWords
+          activeWords := activeWords_comp offset symActiveWords 32
           returnData := .empty,
           execLength := symExecLength + 2} .empty) := by
   intro ss enoughGas mec_small
@@ -167,6 +167,7 @@ theorem X_mload_summary (symState : EVM.State)
   split; aesop (add safe (by omega)) (add safe (by linarith)) (add safe (by contradiction))
   next state n state_ok =>
   repeat split at state_ok <;>
+  -- It is known that `aesop` doesn't fully close the goal in the follwing line
   try aesop (add safe (by omega)) (add safe (by linarith)) (add safe (by contradiction))
   cases state_ok
   have g_pos_pos : 0 < g_pos := by omega

--- a/EvmEquivalence/Summaries/MstoreSummary.lean
+++ b/EvmEquivalence/Summaries/MstoreSummary.lean
@@ -27,21 +27,53 @@ variable (symValidJumps : Array UInt256)
 abbrev mstoreEVM := @Operation.MSTORE .EVM
 
 @[simp]
+abbrev mstore8EVM := @Operation.MSTORE8 .EVM
+
+@[simp]
 abbrev mstore_instr : Option (Operation .EVM × Option (UInt256 × Nat)) :=
   some ⟨mstoreEVM, none⟩
 
 @[simp]
+abbrev mstore8_instr : Option (Operation .EVM × Option (UInt256 × Nat)) :=
+  some ⟨mstore8EVM, none⟩
+
+inductive mstore_op : (Option (Operation .EVM × Option (UInt256 × Nat))) → Type  where
+ | mstore  : mstore_op mstore_instr
+ | mstore8 : mstore_op mstore8_instr
+
+variable {mstore : (Option (Operation .EVM × Option (UInt256 × Nat)))}
+variable (op : mstore_op mstore)
+
+@[simp]
+def mstore_op.get {mstore : (Option (Operation .EVM × Option (UInt256 × Nat)))} (_ : mstore_op mstore) : (Option (Operation .EVM × Option (UInt256 × Nat))) := mstore
+
+--@[simp]
+def mstore_op.t : Operation OperationType.EVM :=
+  match op with
+  | .mstore => (mstore_instr.get rfl).1
+  | .mstore8 => (mstore8_instr.get rfl).1
+/-
+Getter for the `MachineStateOps.mstore*` function
+-/
+@[simp]
+def mstore_op.to_mso : MachineState → UInt256 → UInt256 → MachineState :=
+  match op with
+  | .mstore => EvmYul.MachineState.mstore
+  | .mstore8 => EvmYul.MachineState.mstore8
+
+@[simp]
 abbrev EVM.step_mstore : Transformer :=
-  EVM.step gas gasCost mstore_instr
+  EVM.step gas gasCost op.get
 
 @[simp]
 abbrev EvmYul.step_mstore : Transformer :=
-  EvmYul.step mstoreEVM
+  EvmYul.step op.t
 
 /--
 Theorem needed to bypass the `private` attribute of `EVM.dispatchBinaryMachineStateOp`
  -/
-theorem mstore_bypass_private (symState : EVM.State):
+theorem mstore_bypass_private
+  (symState : EVM.State):
   let ss := {symState with
   stack := symStack,
   pc := symPc
@@ -58,21 +90,46 @@ theorem mstore_bypass_private (symState : EVM.State):
                refundBalance := symRefund}
   returnData := symReturnData,
   execLength := symExecLength}
-  EvmYul.step_mstore ss =
-  EVM.binaryMachineStateOp EvmYul.MachineState.mstore ss := rfl
+  EvmYul.step_mstore op ss =
+  EVM.binaryMachineStateOp op.to_mso ss := by cases op <;> rfl
 
 /--
 The new amount of `activeWords` based after running `MSTORE` with `offset`
 and `currentAC` amount of active words
 -/
-def activeWords_comp :=
-  UInt256.ofNat (symActiveWords.toNat ⊔ (offset.toNat + 32 + 31) / 32)
+def activeWords_comp (l : ℕ) :=
+  UInt256.ofNat (symActiveWords.toNat ⊔ (offset.toNat + l + 31) / 32)
+
+/--
+Different cases for the `activeWords` update
+-/
+@[simp]
+def mstore_op.to_l : ℕ :=
+  match op with
+  | .mstore => 32
+  | .mstore8 => 1
 
 /--
 Writing `value` to `symMemory` starting at `offset`
 -/
-def mstore_memory_write :=
+def mstore_memory_write : ByteArray :=
 value.toByteArray.write 0 symMemory offset.toNat 32
+
+/--
+Writing `value` to `symMemory` starting at `offset`
+-/
+def mstore8_memory_write : ByteArray :=
+(⟨#[UInt8.ofNat value.toNat]⟩ :ByteArray).write 0 symMemory offset.toNat 1
+--value.toByteArray.write 0 symMemory offset.toNat 32
+
+/--
+Different cases to write to memory depending on the `mstore*` opcode
+-/
+@[simp]
+def mstore_op.to_write : UInt256 → UInt256 → ByteArray → ByteArray :=
+  match op with
+  | .mstore => mstore_memory_write
+  | .mstore8 => mstore8_memory_write
 
 theorem EvmYul.step_mstore_summary (symState : EVM.State):
   let ss := {symState with
@@ -91,13 +148,12 @@ theorem EvmYul.step_mstore_summary (symState : EVM.State):
                  refundBalance := symRefund}
     returnData := symReturnData,
     execLength := symExecLength}
-  EvmYul.step_mstore ss =
+  EvmYul.step_mstore op ss =
   .ok {ss with
     stack := symStack,
     pc := symPc + .ofNat 1
-    memory := mstore_memory_write offset value symMemory,
-    activeWords := activeWords_comp offset symActiveWords} := by
-  aesop (add simp [mstore_bypass_private])
+    memory := op.to_write offset value symMemory,
+    activeWords := activeWords_comp offset symActiveWords op.to_l} := by aesop
 
 theorem EVM.step_mstore_summary (gas_pos : 0 < gas) (symState : EVM.State):
   let ss := {symState with
@@ -116,62 +172,57 @@ theorem EVM.step_mstore_summary (gas_pos : 0 < gas) (symState : EVM.State):
                  refundBalance := symRefund}
     returnData := symReturnData,
     execLength := symExecLength}
-  EVM.step_mstore gas gasCost ss =
+  EVM.step_mstore gas gasCost op ss =
     .ok {ss with
           stack := symStack,
           pc := symPc + (.ofNat 1),
           gasAvailable := symGasAvailable - UInt256.ofNat gasCost,
-          memory := mstore_memory_write offset value symMemory,
-          activeWords := activeWords_comp offset symActiveWords
+          memory := op.to_write offset value symMemory,
+          activeWords := activeWords_comp offset symActiveWords op.to_l
           execLength := symExecLength + 1} := by
   cases gas; contradiction
   simp [step_mstore, EVM.step]
   have srw := EvmYul.step_mstore_summary symStack symPc (symGasAvailable - UInt256.ofNat gasCost) symRefund offset value symActiveWords (symExecLength + 1) symReturnData symCode symMemory
-  simp [EvmYul.step_mstore, Operation.MSTORE] at srw; aesop
+  simp [EvmYul.step_mstore, Operation.MSTORE] at srw
+  cases op <;> aesop
+
+/--
+Opcode map to binary
+-/
+def mstore_op.to_bin : ByteArray :=
+  match op with
+  | .mstore  => ⟨#[0x52]⟩
+  | .mstore8 => ⟨#[0x53]⟩
 
 @[simp]
 theorem decode_singleton_mstore :
-  decode ⟨#[0x52]⟩ (.ofNat 0) = some ⟨mstoreEVM, none⟩ := rfl
+  decode op.to_bin (.ofNat 0) = some ⟨op.t, none⟩ := by aesop (add simp [mstore_op.t])
 
 @[simp]
 def value_and_activeWords_gas :=
-  UInt256.ofNat (MachineState.M symActiveWords.toNat value.toNat 32)
+  UInt256.ofNat (MachineState.M symActiveWords.toNat value.toNat op.to_l)
 
 @[simp]
 theorem memoryExpansionCost_mstore (symState : EVM.State)
-  (stack_ok : symState.stack = value :: symStack)
+  (stack_ok : symState.stack = offset :: value :: symStack)
   (symWords_ok : symState.activeWords = symActiveWords):
-  memoryExpansionCost symState mstoreEVM =
-  Cₘ (value_and_activeWords_gas value symActiveWords) - Cₘ symActiveWords := by
-  simp [memoryExpansionCost, memoryExpansionCost.μᵢ']
-  simp [Cₘ, stack_ok, symWords_ok]
-
-/- This theorem is incorrect, needs more constraints to have a positive
- memory expansion gas cost -/
-/-
-Memory expansion cost for the `MSTORE` opcode is strictly positive
--/
-/- theorem mec_mstore (symState : EVM.State)
-  (stack_ok : symState.stack = value :: symStack)
-  (words_ok : symState.activeWords = symActiveWords)
-  (aw_gt_0 : 0 < symActiveWords.toNat)
-  (value_big : symActiveWords.toNat < (value.toNat + 32 + 31) / 32)
-  (enough_gas : symActiveWords.toNat ⊔ (value.toNat + 32 + 31) / 32 < UInt256.size):
-  0 < memoryExpansionCost symState mstoreEVM := by
-  simp [memoryExpansionCost, Cₘ, memoryExpansionCost.μᵢ', GasConstants.Gmemory, Cₘ.QuadraticCeofficient, MachineState.M]
-  rw [UInt256.ofNat_toNat] <;> simp [words_ok, stack_ok] <;> try omega
-  apply Nat.add_lt_add
-  . aesop (add safe (by linarith))
-  . simp [max_eq_right (Nat.le_of_lt value_big)] -/
+  memoryExpansionCost symState op.t =
+  Cₘ (value_and_activeWords_gas offset symActiveWords op) -
+  Cₘ symActiveWords := by
+  cases op <;>
+  aesop (add simp [memoryExpansionCost, memoryExpansionCost.μᵢ'])
 
 theorem X_mstore_summary (symState : EVM.State)
-                         (symStack_ok : symStack.length < 1024):
+                         (symStack_ok : symStack.length <
+                         match op with
+                         | .mstore => 1024
+                         | .mstore8 => 1025):
   let ss := {symState with
     stack := offset :: value :: symStack,
     pc := .ofNat 0
     gasAvailable := symGasAvailable,
     executionEnv := {symState.executionEnv with
-                  code := ⟨#[(0x52 : UInt8)]⟩,
+                  code := op.to_bin,
                   codeOwner := symCodeOwner
                   perm := symPerm},
     accountMap := symAccounts,
@@ -183,49 +234,64 @@ theorem X_mstore_summary (symState : EVM.State)
     returnData := symReturnData,
     execLength := symExecLength}
   -- Assume we have enough gas
-  GasConstants.Gverylow < symGasAvailable.toNat - (memoryExpansionCost ss Operation.MSTORE) →
-  memoryExpansionCost ss Operation.MSTORE < UInt256.size →
+  GasConstants.Gverylow < symGasAvailable.toNat - (memoryExpansionCost ss op.t) →
+  memoryExpansionCost ss op.t < UInt256.size →
   X symGasAvailable.toNat symValidJumps ss =
   .ok (.success {ss with
           stack := symStack,
           pc := .ofNat 1,
-          gasAvailable := symGasAvailable - .ofNat (memoryExpansionCost ss mstoreEVM) - .ofNat GasConstants.Gverylow
-          memory := mstore_memory_write offset value symMemory,
-          activeWords := activeWords_comp offset symActiveWords
+          gasAvailable := symGasAvailable - .ofNat (memoryExpansionCost ss op.t) - .ofNat GasConstants.Gverylow
+          memory := op.to_write offset value symMemory,
+          activeWords := activeWords_comp offset symActiveWords op.to_l
           returnData := .empty,
           execLength := symExecLength + 2} .empty) := by
   intro ss enoughGas mec_small
-  have gavail_pos : 1 < symGasAvailable.toNat := by
+  have gavail_pos : 2 < symGasAvailable.toNat := by
     rw [GasConstants.Gverylow] at enoughGas; omega
   cases g_case : symGasAvailable.toNat; omega
   case succ g_pos =>
-  simp [X, C', δ]
+  simp [X]
   have lt_fls_rw {n m : ℕ} (_ : n < m) : (m < n) = False := by
     simp; apply Nat.ge_of_not_lt; simp; omega
-  simp [(lt_fls_rw enoughGas), α/- , (lt_fls_rw symStack_ok) -/]
-  have fls1 : (symGasAvailable.toNat < memoryExpansionCost ss (@Operation.MSTORE .EVM)) = False :=  by
+  simp [(lt_fls_rw enoughGas), α]
+  have fls1 : (symGasAvailable.toNat < memoryExpansionCost ss op.t) = False :=  by
     rw [Nat.lt_sub_iff_add_lt] at enoughGas
     aesop (add safe (by linarith))
-  have decode_rw : ((decode ss.executionEnv.code ss.pc).getD ⟨@Operation.STOP .EVM, none⟩).1 = Operation.MSTORE := rfl
+  have decode_rw : ((decode ss.executionEnv.code ss.pc).getD ⟨@Operation.STOP .EVM, none⟩).1 = op.t := by aesop
   have gavail_rw1 : ss.gasAvailable.toNat = symGasAvailable.toNat := rfl
   have gavail_rw2 : ss.gasAvailable = symGasAvailable := rfl
   simp [decode_rw, gavail_rw1, gavail_rw2, fls1]
-  simp [InstructionGasGroups.Wcopy, InstructionGasGroups.Wextaccount,
-  InstructionGasGroups.Wzero, InstructionGasGroups.Wbase, InstructionGasGroups.Wverylow]
-  have fls2 : ((symGasAvailable - UInt256.ofNat (memoryExpansionCost ss Operation.MSTORE)).toNat < GasConstants.Gverylow) = False := by
+  let Cgas := C'
+            { toState := ss.toState, gasAvailable := symGasAvailable - UInt256.ofNat (memoryExpansionCost ss op.t),
+              activeWords := ss.activeWords, memory := ss.memory, returnData := ss.returnData, H_return := ss.H_return,
+              pc := ss.pc, stack := ss.stack, execLength := ss.execLength }
+  have Cgas_rw : Cgas op.t = GasConstants.Gverylow := by
+    cases op <;> simp [Cgas, C'] <;> aesop
+  unfold Cgas at Cgas_rw
+  rw [Cgas_rw]
+  have fls2 : ((symGasAvailable - UInt256.ofNat (memoryExpansionCost ss op.t)).toNat < GasConstants.Gverylow) = False := by
     apply eq_false_intro; rw [Nat.not_lt]
     rw [UInt256.toNat_sub_dist, UInt256.ofNat_toNat] <;>
     aesop (add simp [UInt256.ofNat_le, UInt256.ofNat_toNat])
   have ss_lt2_f  (n : ℕ) : (n + 1 + 1 < 2) = False := by simp
-  simp [fls2, ss, ss_lt2_f, Nat.not_lt_of_lt symStack_ok]
-  split; contradiction
-  next state n state_ok =>
-  cases state_ok
-  have g_pos_pos : 0 < g_pos := by omega
-  have step_rw (g : UInt256) := (EVM.step_mstore_summary g_pos GasConstants.Gverylow symStack (.ofNat 0) (symGasAvailable - g) symRefund offset value symActiveWords symExecLength symReturnData ⟨#[(0x52 : UInt8)]⟩ symMemory symAccessedStorageKeys symAccounts symCodeOwner symPerm g_pos_pos symState)
-  simp [EVM.step_mstore, mstore_instr, mstoreEVM, ss] at step_rw
-  simp [step_rw, Except.instMonad, Except.bind]
-  rw [X_bad_pc] <;> aesop (add simp [GasConstants.Gverylow]) (add safe (by omega))
+  simp [fls2, ss]
+  have g_pos0 : 0 < g_pos := by omega
+  have g_pos1 : 1 < g_pos := by omega
+  have step_rw (g : UInt256) := (EVM.step_mstore_summary g_pos GasConstants.Gverylow symStack (.ofNat 0) (symGasAvailable - g) symRefund offset value symActiveWords symExecLength symReturnData op.to_bin symMemory symAccessedStorageKeys symAccounts symCodeOwner symPerm op g_pos0 symState)
+  let op_stack := match op with | .mstore => 1024 | .mstore8 => 1025
+  have : (op_stack < List.length symStack) = False := by aesop
+  cases cop : op <;> simp [δ] <;>
+  (
+    simp_all [op_stack, mstore_op.t, ss_lt2_f, this]; split
+    next _ _ h =>
+      split at h; contradiction
+      split at h; linarith
+      contradiction
+    next state n state_ok =>
+    repeat (split at state_ok; linarith)
+    cases state_ok; simp [step_rw, Except.instMonad, Except.bind]
+    rw [X_bad_pc] <;> first | linarith | congr
+  )
 
 end
 


### PR DESCRIPTION
This PR adds the `MSTORE8` opcode with a new dynamic. It integrates the `MSTORE8` proof obligations within the existing `MSTORE` files.

To achieve this, the PR adds machinery to reason about `MSTORE` _and_ `MSTORE8` at once. This allows us to reuse theorem statements and duplicated proof-boilerplate. 
 
- `Summaries/MstoreSummary.lean`: fully prove the summaries for both opcodes
- `Equivalence/MstoreEquivalence.lean`: add and prove all non-gas related statements except for the proof obligation stating that `mstore8_memory_write (intMap W0) (intMap W1) LOCALMEM_CELL = _Val16`
- `Interfaces/FuncInterface`: generalize width parameter of theorem `memoryUsageUpdate_rw`