### PR TITLE
Remove blueprint pdf generation

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -79,9 +79,9 @@ jobs:
             pip install --upgrade pip requests wheel
             pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
             pip install leanblueprint
-            leanblueprint pdf
+            # leanblueprint pdf
             mkdir -p home_page
-            cp blueprint/print/print.pdf home_page/blueprint.pdf
+            # cp blueprint/print/print.pdf home_page/blueprint.pdf
             leanblueprint web
             cp -r blueprint/web home_page/blueprint
 


### PR DESCRIPTION
Currently the pdf generation for the blueprint is broken, but not the web. This PR disables the pdf generation for the moment since it's not nearly as important as the web version.