### PR TITLE
Don't enforce `checkdecls` nor creation of pdf

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -79,15 +79,15 @@ jobs:
             pip install --upgrade pip requests wheel
             pip install pygraphviz --global-option=build_ext --global-option="-L/usr/lib/graphviz/" --global-option="-R/usr/lib/graphviz/"
             pip install leanblueprint
-            # leanblueprint pdf
+            leanblueprint pdf || true
             mkdir -p home_page
-            # cp blueprint/print/print.pdf home_page/blueprint.pdf
+            cp blueprint/print/print.pdf home_page/blueprint.pdf || true
             leanblueprint web
             cp -r blueprint/web home_page/blueprint
 
       - name: Check declarations mentioned in the blueprint exist in Lean code
         run: |
-            ~/.elan/bin/lake exe checkdecls blueprint/lean_decls
+            ~/.elan/bin/lake exe checkdecls blueprint/lean_decls || true
 
       - name: Copy API documentation to `home_page/docs`
         run: cp -r .lake/build/doc home_page/docs

--- a/blueprint/src/chapter/gen-code.tex
+++ b/blueprint/src/chapter/gen-code.tex
@@ -121,7 +121,7 @@ Truncated division.
 \begin{definition}[modInt]\label{def:modInt}\lean{«_modInt_»}\leanok\uses{def:SortInt}
 Euclidian modulus.
 \end{definition}
-\begin{definition}[powModInt]\label{powModInt}\lean{«_powModInt_»}\leanok\uses{def:SortInt}
+\begin{definition}[powMod]\label{powModInt}\lean{powmod}\leanok\uses{def:SortInt}
 Integer powmod.
 
 \textbf{Warning:} Leanblueprint has a problem with \texttt{$\backslash$lean\{\}}
@@ -134,7 +134,7 @@ Max operation.
 \begin{definition}[log2Int]\label{log2Int}\lean{«log2Int(_)_INT-COMMON_Int_Int»}\leanok\uses{def:SortInt}
 $log_2$ on positive integers.
 \end{definition}
-\begin{definition}[notInt]\label{notInt}\lean{«notInt_»}\leanok\uses{def:SortInt}
+\begin{definition}[notInt]\label{notInt}\leanok\uses{def:SortInt}%\lean{«~Int_»}
 Integer complement.
 
 \textbf{Warning:} Leanblueprint has a problem with \texttt{$\backslash$lean\{\}}


### PR DESCRIPTION
When creating the blueprint, the step for checking that the declarations referenced in the blueprint are indeed in the code is doomed to fail since the blueprint renders commas in the declarations' names as new spaces, and as such we get the following error:

```
«maxInt(_ is missing.
_)_INT-COMMON_Int_Int_Int» is missing.
«Int2Bytes(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Bytes_Int_Int_Endianness» is missing.
«Bytes2Int(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Int_Bytes_Endianness_Signedness» is missing.
«padRightBytes(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» is missing.
«padLeftBytes(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» is missing.
«replaceAtBytes(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Bytes_Bytes_Int_Bytes» is missing.
«substrBytes(_ is missing.
_ is missing.
_)_BYTES-HOOKED_Bytes_Bytes_Int_Int» is missing.
```